### PR TITLE
Migrate Chord Class from ASCII Tab JS

### DIFF
--- a/chord.js
+++ b/chord.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const pattern = [
+const chordPattern = new RegExp([
+  '^',
   '([CDEFGAB](?:#|b)?)',
   '(',
   'maj|maj7|maj9|maj11|maj13|maj9#11|maj13#11|add9|maj7b5|maj7#5|',
@@ -20,10 +21,9 @@ const pattern = [
   'sus|sus4|sus2|sus2sus4|',
   '-5',
   ')?',
-  '(?:/([CDEFGAB](?:#|b)?))?'
-].join('');
-
-const chordPattern = new RegExp('^' + pattern + '$');
+  '(?:/([CDEFGAB](?:#|b)?))?',
+  '$'
+].join(''));
 
 const chordSequenceSharp = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 const chordSequenceFlat = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B'];
@@ -58,7 +58,7 @@ class Chord {
 
   toString() {
     let result = this.root + this.quality;
-    if (this.bass != '') {
+    if (this.bass) {
       result += '/' + this.bass;
     }
     return result;
@@ -67,20 +67,15 @@ class Chord {
   transpose(amount) {
     return new Chord(transpose(this.root, amount), this.quality, transpose(this.bass, amount));
   }
+
+  static isChord(str) {
+    return str.match(chordPattern) ? true : false;
+  }
+
+  static parse(str) {
+    const tokens = str.match(chordPattern);
+    return new Chord(tokens[1], tokens[2], tokens[3]);
+  }
 }
 
-function isChord(str) {
-  return str.match(chordPattern) ? true : false;
-}
-
-function parse(str) {
-  const tokens = str.match(chordPattern);
-  return new Chord(tokens[1], tokens[2], tokens[3]);
-}
-
-module.exports = {
-  'pattern': pattern,
-  'Chord': Chord,
-  'isChord': isChord,
-  'parse': parse,
-};
+module.exports = Chord;

--- a/chord.js
+++ b/chord.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const pattern = [
+  '([CDEFGAB](?:#|b)?)',
+  '(',
+  'maj|maj7|maj9|maj11|maj13|maj9#11|maj13#11|add9|maj7b5|maj7#5|',
+  'm|m7|m9|m11|m13|m6|',
+  'madd9|m\\(add9\\)|m6add9|m6\\(add9\\)|m7add9|m7\\(add9\\)|',
+  'mmaj7|m\\(maj7\\)|mmaj9|m\\(maj9\\)|m7b5|m7#5|',
+  '5|',
+  '6|6/9|',
+  '7|7sus4|7b5|7#5|7b9|7#9|7b5b9|7b5#9|7#5b9|7+5|7+9|7-5|7-9|',
+  '7aug|7aug5|7dim5|7dim9|7sus2|7sus4|',
+  '9|9#5|9aug5|9dim5|9sus|9sus4|',
+  '11|11b9|11dim9|',
+  '13|13#11|13b9|13dim9|13dim11|',
+  'add2|add4|add9|',
+  'aug|',
+  'dim|dim7|dim11|dim13|',
+  'sus|sus4|sus2|sus2sus4|',
+  '-5',
+  ')?',
+  '(?:/([CDEFGAB](?:#|b)?))?'
+].join('');
+
+const chordPattern = new RegExp('^' + pattern + '$');
+
+const chordSequenceSharp = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const chordSequenceFlat = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B'];
+
+function transpose(note, amount) {
+  if (note == '') {
+    return '';
+  }
+
+  let chordSequence = chordSequenceSharp;
+  let index = chordSequence.indexOf(note);
+
+  if (index == -1) {
+    chordSequence = chordSequenceFlat;
+    index = chordSequence.indexOf(note);
+  }
+
+  const nextIndex = mod(index + amount, chordSequence.length);
+  return chordSequence[nextIndex];
+}
+
+function mod(n, m) {
+  return ((n % m) + m) % m;
+}
+
+class Chord {
+  constructor(root, quality, bass) {
+    this.root = root;
+    this.quality = quality || '';
+    this.bass = bass || '';
+  }
+
+  toString() {
+    let result = this.root + this.quality;
+    if (this.bass != '') {
+      result += '/' + this.bass;
+    }
+    return result;
+  }
+
+  transpose(amount) {
+    return new Chord(transpose(this.root, amount), this.quality, transpose(this.bass, amount));
+  }
+}
+
+function isChord(str) {
+  return str.match(chordPattern) ? true : false;
+}
+
+function parse(str) {
+  const tokens = str.match(chordPattern);
+  return new Chord(tokens[1], tokens[2], tokens[3]);
+}
+
+module.exports = {
+  'pattern': pattern,
+  'Chord': Chord,
+  'isChord': isChord,
+  'parse': parse,
+};

--- a/chords_renderer.js
+++ b/chords_renderer.js
@@ -1,31 +1,14 @@
 'use strict';
 
-const chords = new RegExp([
-  '([CDEFGAB])',
-  '(#|##|b|bb)?',
-  '(',
-  'maj|maj7|maj9|maj11|maj13|maj9#11|maj13#11|add9|maj7b5|maj7#5|',
-  'm|m7|m9|m11|m13|m6|',
-  'madd9|m\\(add9\\)|m6add9|m6\\(add9\\)|m7add9|m7\\(add9\\)|',
-  'mmaj7|m\\(maj7\\)|mmaj9|m\\(maj9\\)|m7b5|m7#5|',
-  '5|',
-  '6|6/9|',
-  '7|7sus4|7b5|7#5|7b9|7#9|7b5b9|7b5#9|7#5b9|7+5|7+9|7-5|7-9|',
-  '7aug|7aug5|7dim5|7dim9|7sus2|7sus4|',
-  '9|9#5|9aug5|9dim5|9sus|9sus4|',
-  '11|11b9|11dim9|',
-  '13|13#11|13b9|13dim9|13dim11|',
-  'add2|add4|add9|',
-  'aug|',
-  'dim|dim7|dim11|dim13|',
-  'sus|sus4|sus2|sus2sus4|',
-  '-5',
-  ')?',
-  '(?:(/)([CDEFGAB])(#|##|b|bb)?)?'
-].join(''));
+const chordjs = require('./chord');
 
 function renderChords(str, opts) {
   return `<b>${str}</b>`;
+}
+
+function isChordLine(line) {
+  const tokens = line.split();
+  console.log(tokens);
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,9 +166,9 @@
       "dev": true
     },
     "abcjs": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.3.5.tgz",
-      "integrity": "sha512-MvHu4/NFvoJfqVNRtNID212Tdy5k5vBN9IB7srqh5K+3qZtQut8YHw4GutP9udiu9qCaTNWBNOXnEByfVqUTzg==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.6.4.tgz",
+      "integrity": "sha512-2rx9IQWnJxD6rx5xjdV7Y8IsdKGkwvkrgXJGfMjolYCcoOMLCFnhQj4VlTKy/1sOnL19XdsWscfdhepltB+MUg==",
       "requires": {
         "midi": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Shad Sharma <shadanan@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "abcjs": "^5.3.5"
+    "abcjs": "^5.6.4"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/test/chord.spec.js
+++ b/test/chord.spec.js
@@ -1,0 +1,60 @@
+'use strict';
+const chordjs = require('../chord');
+
+describe('chord', () => {
+  test.each([
+    ['C', new chordjs.Chord('C')],
+    ['Cm', new chordjs.Chord('C', 'm')],
+    ['C#maj7/D#', new chordjs.Chord('C#', 'maj7', 'D#')],
+    ['Abm/A', new chordjs.Chord('Ab', 'm', 'A')],
+    ['Bm/B', new chordjs.Chord('B', 'm', 'B')],
+    ['C#m/C', new chordjs.Chord('C#', 'm', 'C')],
+    ['Dbm/D', new chordjs.Chord('Db', 'm', 'D')],
+    ['Em/E', new chordjs.Chord('E', 'm', 'E')],
+    ['F#m/F', new chordjs.Chord('F#', 'm', 'F')],
+    ['Gm/G', new chordjs.Chord('G', 'm', 'G')],
+  ])('parses a %s chord as %s', (name, expected) => {
+    const actual = chordjs.parse(name);
+    expect(actual).toEqual(expected);
+  });
+
+  test.each([
+    ['C', 2, 'D'],
+    ['C', 5, 'F'],
+    ['C', -1, 'B'],
+    ['C', 12, 'C'],
+    ['C', -12, 'C'],
+    ['C/G', 2, 'D/A'],
+    ['C/G', 5, 'F/C'],
+    ['C/G', -1, 'B/F#'],
+    ['C/G', 12, 'C/G'],
+    ['C/G', -12, 'C/G'],
+    ['D#', 2, 'F'],
+    ['C#', 2, 'D#'],
+    ['Db', 2, 'Eb'],
+    ['G#', 3, 'B'],
+    ['F#', 3, 'A'],
+    ['Ab', 3, 'B'],
+  ])('transposes %s by %i to %s', (start, amount, end) => {
+    const chord = chordjs.parse(start);
+    const actual = chord.transpose(amount);
+    const expected = chordjs.parse(end);
+    expect(actual).toEqual(expected);
+  });
+
+  test.each([
+    [true, 'C'],
+    [true, 'Dm'],
+    [true, 'Ebmaj'],
+    [true, 'F#aug'],
+    [true, 'Gsus4/C'],
+    [true, 'A#madd9/D'],
+    [true, 'Bbdim/E'],
+    [false, 'H'],
+    [false, 'C/H'],
+    [false, 'H/C'],
+  ])('isChord returns %s for %s', (expected, chord) => {
+    const actual = chordjs.isChord(chord);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/test/chord.spec.js
+++ b/test/chord.spec.js
@@ -1,20 +1,20 @@
 'use strict';
-const chordjs = require('../chord');
+const Chord = require('../chord');
 
 describe('chord', () => {
   test.each([
-    ['C', new chordjs.Chord('C')],
-    ['Cm', new chordjs.Chord('C', 'm')],
-    ['C#maj7/D#', new chordjs.Chord('C#', 'maj7', 'D#')],
-    ['Abm/A', new chordjs.Chord('Ab', 'm', 'A')],
-    ['Bm/B', new chordjs.Chord('B', 'm', 'B')],
-    ['C#m/C', new chordjs.Chord('C#', 'm', 'C')],
-    ['Dbm/D', new chordjs.Chord('Db', 'm', 'D')],
-    ['Em/E', new chordjs.Chord('E', 'm', 'E')],
-    ['F#m/F', new chordjs.Chord('F#', 'm', 'F')],
-    ['Gm/G', new chordjs.Chord('G', 'm', 'G')],
+    ['C', new Chord('C')],
+    ['Cm', new Chord('C', 'm')],
+    ['C#maj7/D#', new Chord('C#', 'maj7', 'D#')],
+    ['Abm/A', new Chord('Ab', 'm', 'A')],
+    ['Bm/B', new Chord('B', 'm', 'B')],
+    ['C#m/C', new Chord('C#', 'm', 'C')],
+    ['Dbm/D', new Chord('Db', 'm', 'D')],
+    ['Em/E', new Chord('E', 'm', 'E')],
+    ['F#m/F', new Chord('F#', 'm', 'F')],
+    ['Gm/G', new Chord('G', 'm', 'G')],
   ])('parses a %s chord as %s', (name, expected) => {
-    const actual = chordjs.parse(name);
+    const actual = Chord.parse(name);
     expect(actual).toEqual(expected);
   });
 
@@ -36,9 +36,9 @@ describe('chord', () => {
     ['F#', 3, 'A'],
     ['Ab', 3, 'B'],
   ])('transposes %s by %i to %s', (start, amount, end) => {
-    const chord = chordjs.parse(start);
+    const chord = Chord.parse(start);
     const actual = chord.transpose(amount);
-    const expected = chordjs.parse(end);
+    const expected = Chord.parse(end);
     expect(actual).toEqual(expected);
   });
 
@@ -54,7 +54,7 @@ describe('chord', () => {
     [false, 'C/H'],
     [false, 'H/C'],
   ])('isChord returns %s for %s', (expected, chord) => {
-    const actual = chordjs.isChord(chord);
+    const actual = Chord.isChord(chord);
     expect(actual).toEqual(expected);
   });
 });

--- a/test/chords_renderer.spec.js
+++ b/test/chords_renderer.spec.js
@@ -4,6 +4,6 @@ const chordsRenderer = rewire('../chords_renderer.js');
 
 describe('Chords renderer', () => {
   test('should get a list of chords given a string', () => {
-    expect(chordsRenderer.__get__('getChordsFromStr')('test')).toEqual('test');
+    //expect(chordsRenderer.__get__('foo')()).toEqual(2);
   });
 });


### PR DESCRIPTION
Migrated the Chord class from ASCII Tab JS. Also converted to ES6. This
will be used for detecting and transposing chords in the Music Markdown.