### PR TITLE
Fix all current lint errors, add linter to tests

### DIFF
--- a/abc_renderer.js
+++ b/abc_renderer.js
@@ -1,9 +1,8 @@
 'use strict';
-var abc = require('abcjs');
-
+const abc = require('abcjs');
 
 function renderAbc(str, opts) {
-  var div = document.createElement("div");
+  const div = document.createElement('div');
   abc.renderAbc(div, str, {
     visualTranspose: opts.transpose
   });
@@ -14,4 +13,4 @@ function renderAbc(str, opts) {
 module.exports = {
   'lang': 'abc',
   'callback': renderAbc
-}
+};

--- a/chords_renderer.js
+++ b/chords_renderer.js
@@ -1,14 +1,7 @@
 'use strict';
 
-const chordjs = require('./chord');
-
 function renderChords(str, opts) {
   return `<b>${str}</b>`;
-}
-
-function isChordLine(line) {
-  const tokens = line.split();
-  console.log(tokens);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function MarkdownMusic(md, musicOpts) {
   // Renderer configuration functions
   md.setTranspose = function(transpose) {
     md.musicOpts.transpose = transpose;
-  }
+  };
 };
 
 module.exports = MarkdownMusic;

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,8 +169,11 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.6.4.tgz",
       "integrity": "sha512-2rx9IQWnJxD6rx5xjdV7Y8IsdKGkwvkrgXJGfMjolYCcoOMLCFnhQj4VlTKy/1sOnL19XdsWscfdhepltB+MUg==",
-      "requires": {
-        "midi": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
+      "dependencies": {
+        "midi": {
+          "version": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2",
+          "from": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
+        }
       }
     },
     "acorn": {
@@ -3531,10 +3534,6 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
       }
-    },
-    "midi": {
-      "version": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2",
-      "from": "git+https://github.com/paulrosen/MIDI.js.git#abcjs"
     },
     "mime-db": {
       "version": "1.37.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Renderer for Music Markdown.",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "pretest": "eslint .",
+    "fix-lint": "eslint . --fix"
   },
   "keywords": [
     "markdown-it-plugin"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "pretest": "eslint .",
+    "posttest": "eslint .",
     "fix-lint": "eslint . --fix"
   },
   "keywords": [

--- a/test/chords_renderer.spec.js
+++ b/test/chords_renderer.spec.js
@@ -1,9 +1,0 @@
-const rewire = require('rewire');
-
-const chordsRenderer = rewire('../chords_renderer.js');
-
-describe('Chords renderer', () => {
-  test('should get a list of chords given a string', () => {
-    //expect(chordsRenderer.__get__('foo')()).toEqual(2);
-  });
-});


### PR DESCRIPTION
Fixes any current lint errors (yay error free!), and adds eslint to post test. Now running `npm test` will first run tests, then check for any lint errors.

Fixes #6 