### PR TITLE
Add ability to transpose on chords.

### DIFF
--- a/renderers/chords_renderer.js
+++ b/renderers/chords_renderer.js
@@ -2,7 +2,7 @@
 
 const parseVerse = require('../parsers/verse.js')['parseVerse'];
 
-function createHtmlChordChart(verse) {
+function createHtmlChordChart(verse, opts) {
   const chordChartHtml = document.createElement('div');
   chordChartHtml.className = 'chart';
 
@@ -10,7 +10,7 @@ function createHtmlChordChart(verse) {
     const verseDiv = document.createElement('div');
     verseDiv.className = 'verse';
 
-    createListOfWrappedVoices(phrase)
+    createListOfWrappedVoices(phrase, opts ? opts.transpose : undefined)
       .forEach((event) => {
         verseDiv.appendChild(event);
       });
@@ -21,7 +21,7 @@ function createHtmlChordChart(verse) {
   return chordChartHtml;
 }
 
-function createListOfWrappedVoices(phrase) {
+function createListOfWrappedVoices(phrase, transposeAmount) {
   // Assumes voices are sorted by index and grouped by voice.
   const voiceElements = new Map();
 
@@ -31,6 +31,10 @@ function createListOfWrappedVoices(phrase) {
         voiceElements.set(voiceName, new Map([['index', 0], ['parentElement', document.createElement('div')]]));
 
         voiceElements.get(voiceName).get('parentElement').className = voiceName;
+      }
+
+      if (transposeAmount && voiceName.startsWith('c') && typeof event.content.transpose === 'function') {
+        event.content = event.content.transpose(transposeAmount);
       }
 
       const voice = voiceElements.get(voiceName);
@@ -67,7 +71,7 @@ function appendVoiceContentDiv(parentVoice, text, whitespace) {
 function renderChords(str, opts) {
   const verse = parseVerse(str);
 
-  const htmlChart = createHtmlChordChart(verse);
+  const htmlChart = createHtmlChordChart(verse, opts);
 
   return htmlChart.outerHTML;
 }

--- a/renderers/chords_renderer.spec.js
+++ b/renderers/chords_renderer.spec.js
@@ -107,9 +107,7 @@ describe('JSON to HTML converter', () => {
     ];
 
     const actualHtmlList = createListOfWrappedVoices(chordChartJson)
-      .map((html) => {
-        return html.outerHTML;
-      });
+      .map((html) => html.outerHTML);
 
     expect(actualHtmlList).toEqual(expectedChordChartHtmlList);
   });
@@ -171,5 +169,39 @@ describe('JSON to HTML converter', () => {
       '</div>';
 
     expect(createHtmlChordChart(verse).outerHTML).toEqual(expectedDiv);
+  });
+
+  test('should transpose a chord if transpose is provided', () => {
+    const phrase = new Map([
+      ['c1', [{ index: 0, content: new Chord('C') }]]
+    ]);
+
+    const expectedPhraseHtml = [
+      '<div class="c1">' +
+        '<div>C#</div>' +
+      '</div>'
+    ];
+
+    const wrappedVoices = createListOfWrappedVoices(phrase, 1)
+      .map((html) => html.outerHTML);
+
+    expect(wrappedVoices).toEqual(expectedPhraseHtml);
+  });
+
+  test('should not try to transpose anything that is not a chord', () => {
+    const phrase = new Map([
+      ['l1', [{ index: 0, content: 'test' }]]
+    ]);
+
+    const expectedPhraseHtml = [
+      '<div class="l1">' +
+        '<div>test</div>' +
+      '</div>'
+    ];
+
+    const wrappedVoices = createListOfWrappedVoices(phrase, 1)
+      .map((html) => html.outerHTML);
+
+    expect(wrappedVoices).toEqual(expectedPhraseHtml);
   });
 });


### PR DESCRIPTION
Fixes #16 

Pass through the music options to render functions. Call into Chord's transpose function to get actual chord string.

![transpose](https://user-images.githubusercontent.com/5377267/53281409-d83b9800-36dc-11e9-8ede-dab78273863b.gif)
