### PR TITLE
Create generic voice colors, with preset default.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
       "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.6.4.tgz",
       "integrity": "sha512-2rx9IQWnJxD6rx5xjdV7Y8IsdKGkwvkrgXJGfMjolYCcoOMLCFnhQj4VlTKy/1sOnL19XdsWscfdhepltB+MUg==",
       "requires": {
-        "midi": "git+https://github.com/paulrosen/MIDI.js.git#abcjs"
+        "midi": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
       }
     },
     "acorn": {
@@ -1688,8 +1688,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1710,14 +1709,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1732,20 +1729,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1862,8 +1856,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1875,7 +1868,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1890,7 +1882,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1898,14 +1889,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1924,7 +1913,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2005,8 +1993,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2018,7 +2005,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2104,8 +2090,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2141,7 +2126,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2161,7 +2145,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2205,14 +2188,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4135,6 +4116,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "randomcolor": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/randomcolor/-/randomcolor-0.5.4.tgz",
+      "integrity": "sha512-nYd4nmTuuwMFzHL6W+UWR5fNERGZeVauho8mrJDUSXdNDbao4rbrUwhuLgKC/j8VCS5+34Ria8CsTDuBjrIrQA=="
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "author": "Shad Sharma <shadanan@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "abcjs": "^5.6.4"
+    "abcjs": "^5.6.4",
+    "randomcolor": "^0.5.4"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/renderers/chords_renderer.spec.js
+++ b/renderers/chords_renderer.spec.js
@@ -10,106 +10,153 @@ const createHtmlChordChart = chordsrendererjs.__get__('createHtmlChordChart');
 const createListOfWrappedVoices = chordsrendererjs.__get__('createListOfWrappedVoices');
 const appendVoiceContentDiv = chordsrendererjs.__get__('appendVoiceContentDiv');
 
+const VoiceColors = chordsrendererjs.__get__('VoiceColors');
+
 describe('JSON to HTML converter', () => {
+  const defaultColors = ['blue', 'black', 'red', 'green', 'purple', 'teal'];
+
   test('should wrap voice in div', () => {
     const parentDiv = document.createElement('div');
-    appendVoiceContentDiv(parentDiv, 'The', 1);
+    appendVoiceContentDiv(parentDiv, 'The', 1, 'c1');
 
-    const expectedDiv = '<div><div> </div><div>The</div></div>';
+    const expectedDiv = '<div><div> </div><div class="c1">The</div></div>';
 
     expect(parentDiv.outerHTML).toEqual(expectedDiv);
   });
 
   test('should not include spaces div if there is no expected whitespace', () => {
     const parentDiv = document.createElement('div');
-    appendVoiceContentDiv(parentDiv, new Chord('C'), 0);
+    appendVoiceContentDiv(parentDiv, new Chord('C'), 0, 'c1');
 
-    const expectedDiv = '<div><div>C</div></div>';
+    const expectedDiv = '<div><div class="c1">C</div></div>';
 
     expect(parentDiv.outerHTML).toEqual(expectedDiv);
   });
 
   test('should append several chords to same parent div', () => {
     const parentDiv = document.createElement('div');
-    appendVoiceContentDiv(parentDiv, new Chord('C'), 0);
-    appendVoiceContentDiv(parentDiv, new Chord('G'), 5);
+    appendVoiceContentDiv(parentDiv, new Chord('C'), 0, 'c1');
+    appendVoiceContentDiv(parentDiv, new Chord('G'), 5, 'c1');
 
-    const expectedDiv = '<div><div>C</div><div>     </div><div>G</div></div>';
+    const expectedDiv = '<div><div class="c1">C</div><div>     </div><div class="c1">G</div></div>';
 
     expect(parentDiv.outerHTML).toEqual(expectedDiv);
   });
 
-  test('should convert a list of voice events (a chord chard) to wrapped divs', () => {
-    const chordChartJson = new Map([
-      ['c1', [
-        { index: 4, content: new Chord('G') },
-        { index: 12, content: new Chord('F') },
-        { index: 20, content: new Chord('Am') },
-        { index: 29, content: new Chord('G') },
-        { index: 40, content: new Chord('F') },
-        { index: 47, content: new Chord('C') },
-      ]],
-      ['c2', [
-        { index: 4, content: new Chord('C') },
-        { index: 12, content: new Chord('D') },
-        { index: 20, content: new Chord('Cm') },
-        { index: 29, content: new Chord('F') },
-        { index: 40, content: new Chord('G') },
-        { index: 47, content: new Chord('B') },
-      ]],
-      ['l1', [
-        { index: 0, content: 'The' },
-        { index: 4, content: 'longest' },
-        { index: 12, content: 'word' },
-        { index: 17, content: 'is' },
-        { index: 20, content: 'supercalifragilisticexpialidocious' },
-      ]],
-      ['l2', [
-        { index: 40, content: 'supercalifragilisticexpialidocious' },
-      ]],
-      ['a1', [
-        { index: 4, content: 'crash!' },
-      ]]
-    ]);
+  describe('wrapped voices', () => {
+    let voiceColors;
+    beforeEach(() => {
+      voiceColors = new VoiceColors();
+    });
 
-    const expectedChordChartHtmlList = [
-      '<div class="c1">' +
-        '<div>    </div><div>G</div>' +
-        '<div>       </div><div>F</div>' +
-        '<div>       </div><div>Am</div>' +
-        '<div>       </div><div>G</div>' +
-        '<div>          </div><div>F</div>' +
-        '<div>      </div><div>C</div>' +
-      '</div>',
+    test('should convert a list of voice events (a chord chard) to wrapped divs', () => {
+      const chordChartJson = new Map([
+        ['c1', [
+          { index: 4, content: new Chord('G') },
+          { index: 12, content: new Chord('F') },
+          { index: 20, content: new Chord('Am') },
+          { index: 29, content: new Chord('G') },
+          { index: 40, content: new Chord('F') },
+          { index: 47, content: new Chord('C') },
+        ]],
+        ['c2', [
+          { index: 4, content: new Chord('C') },
+          { index: 12, content: new Chord('D') },
+          { index: 20, content: new Chord('Cm') },
+          { index: 29, content: new Chord('F') },
+          { index: 40, content: new Chord('G') },
+          { index: 47, content: new Chord('B') },
+        ]],
+        ['l1', [
+          { index: 0, content: 'The' },
+          { index: 4, content: 'longest' },
+          { index: 12, content: 'word' },
+          { index: 17, content: 'is' },
+          { index: 20, content: 'supercalifragilisticexpialidocious' },
+        ]],
+        ['l2', [
+          { index: 40, content: 'supercalifragilisticexpialidocious' },
+        ]],
+        ['a1', [
+          { index: 4, content: 'crash!' },
+        ]]
+      ]);
 
-      '<div class="c2">' +
-        '<div>    </div><div>C</div>' +
-        '<div>       </div><div>D</div>' +
-        '<div>       </div><div>Cm</div>' +
-        '<div>       </div><div>F</div>' +
-        '<div>          </div><div>G</div>' +
-        '<div>      </div><div>B</div>' +
-      '</div>',
+      const expectedChordChartHtmlList = [
+        `<div class="voice" style="color: ${defaultColors[0]};">` +
+          '<div>    </div><div class="c1">G</div>' +
+          '<div>       </div><div class="c1">F</div>' +
+          '<div>       </div><div class="c1">Am</div>' +
+          '<div>       </div><div class="c1">G</div>' +
+          '<div>          </div><div class="c1">F</div>' +
+          '<div>      </div><div class="c1">C</div>' +
+        '</div>',
 
-      '<div class="l1">' +
-        '<div>The</div>' +
-        '<div> </div><div>longest</div>' +
-        '<div> </div><div>word</div>' +
-        '<div> </div><div>is</div>' +
-        '<div> </div><div>supercalifragilisticexpialidocious</div>' +
-      '</div>',
+        `<div class="voice" style="color: ${defaultColors[1]};">` +
+          '<div>    </div><div class="c2">C</div>' +
+          '<div>       </div><div class="c2">D</div>' +
+          '<div>       </div><div class="c2">Cm</div>' +
+          '<div>       </div><div class="c2">F</div>' +
+          '<div>          </div><div class="c2">G</div>' +
+          '<div>      </div><div class="c2">B</div>' +
+        '</div>',
 
-      '<div class="l2">' +
-        '<div>                                        </div><div>supercalifragilisticexpialidocious</div></div>',
-      '<div class="a1">' +
-        '<div>    </div><div>crash!</div>' +
-      '</div>'
-    ];
+        `<div class="voice" style="color: ${defaultColors[2]};">` +
+          '<div class="l1">The</div>' +
+          '<div> </div><div class="l1">longest</div>' +
+          '<div> </div><div class="l1">word</div>' +
+          '<div> </div><div class="l1">is</div>' +
+          '<div> </div><div class="l1">supercalifragilisticexpialidocious</div>' +
+        '</div>',
 
-    const actualHtmlList = createListOfWrappedVoices(chordChartJson)
-      .map((html) => html.outerHTML);
+        `<div class="voice" style="color: ${defaultColors[3]};">` +
+          '<div>                                        </div>' +
+          '<div class="l2">supercalifragilisticexpialidocious</div>' +
+        '</div>',
+        `<div class="voice" style="color: ${defaultColors[4]};">` +
+          '<div>    </div><div class="a1">crash!</div>' +
+        '</div>'
+      ];
 
-    expect(actualHtmlList).toEqual(expectedChordChartHtmlList);
+      const actualHtmlList = createListOfWrappedVoices(chordChartJson, undefined, voiceColors)
+        .map((html) => html.outerHTML);
+
+      expect(actualHtmlList).toEqual(expectedChordChartHtmlList);
+    });
+
+    test('should transpose a chord if transpose is provided', () => {
+      const phrase = new Map([
+        ['c1', [{ index: 0, content: new Chord('C') }]]
+      ]);
+
+      const expectedPhraseHtml = [
+        `<div class="voice" style="color: ${defaultColors[0]};">` +
+          '<div class="c1">C#</div>' +
+        '</div>'
+      ];
+
+      const wrappedVoices = createListOfWrappedVoices(phrase, 1, voiceColors)
+        .map((html) => html.outerHTML);
+
+      expect(wrappedVoices).toEqual(expectedPhraseHtml);
+    });
+
+    test('should not try to transpose anything that is not a chord', () => {
+      const phrase = new Map([
+        ['l1', [{ index: 0, content: 'test' }]]
+      ]);
+
+      const expectedPhraseHtml = [
+        `<div class="voice" style="color: ${defaultColors[0]};">` +
+          '<div class="l1">test</div>' +
+        '</div>'
+      ];
+
+      const wrappedVoices = createListOfWrappedVoices(phrase, 1, voiceColors)
+        .map((html) => html.outerHTML);
+
+      expect(wrappedVoices).toEqual(expectedPhraseHtml);
+    });
   });
 
   test('should wrap a chord chart in chord chart class div', () => {
@@ -119,8 +166,8 @@ describe('JSON to HTML converter', () => {
 
     const expectedChordChartHtml = '<div class="chart">' +
       '<div class="verse">' +
-        '<div class="l1">' +
-        '<div>short</div>' +
+        `<div class="voice" style="color: ${defaultColors[0]};">` +
+        '<div class="l1">short</div>' +
       '</div></div></div>';
 
     expect(createHtmlChordChart(shortChart).outerHTML).toEqual(expectedChordChartHtml);
@@ -150,20 +197,20 @@ describe('JSON to HTML converter', () => {
     const expectedDiv =
       '<div class="chart">' +
         '<div class="verse">' +
-          '<div class="c1">' +
-            '<div>C</div>' +
-            '<div>   </div><div>G</div>' +
+          `<div class="voice" style="color: ${defaultColors[0]};">` +
+            '<div class="c1">C</div>' +
+            '<div>   </div><div class="c1">G</div>' +
           '</div>' +
-          '<div class="l1">' +
-            '<div>Test</div>' +
+          `<div class="voice" style="color: ${defaultColors[1]};">` +
+            '<div class="l1">Test</div>' +
           '</div>' +
         '</div>' +
         '<div class="verse">' +
-          '<div class="c1">' +
-            '<div>A</div>' +
+          `<div class="voice" style="color: ${defaultColors[0]};">` +
+            '<div class="c1">A</div>' +
           '</div>' +
-          '<div class="l1">' +
-            '<div>Song</div>' +
+          `<div class="voice" style="color: ${defaultColors[1]};">` +
+            '<div class="l1">Song</div>' +
           '</div>' +
         '</div>' +
       '</div>';
@@ -171,37 +218,33 @@ describe('JSON to HTML converter', () => {
     expect(createHtmlChordChart(verse).outerHTML).toEqual(expectedDiv);
   });
 
-  test('should transpose a chord if transpose is provided', () => {
-    const phrase = new Map([
-      ['c1', [{ index: 0, content: new Chord('C') }]]
-    ]);
+  test('should get default colors for first voices', () => {
+    const voiceColors = new VoiceColors();
 
-    const expectedPhraseHtml = [
-      '<div class="c1">' +
-        '<div>C#</div>' +
-      '</div>'
-    ];
-
-    const wrappedVoices = createListOfWrappedVoices(phrase, 1)
-      .map((html) => html.outerHTML);
-
-    expect(wrappedVoices).toEqual(expectedPhraseHtml);
+    defaultColors.forEach((color) => {
+      expect(voiceColors.getVoiceColor(color)).toEqual(color);
+    });
   });
 
-  test('should not try to transpose anything that is not a chord', () => {
-    const phrase = new Map([
-      ['l1', [{ index: 0, content: 'test' }]]
-    ]);
+  test('should get random color after defaults expire', () => {
+    const voiceColors = new VoiceColors();
 
-    const expectedPhraseHtml = [
-      '<div class="l1">' +
-        '<div>test</div>' +
-      '</div>'
-    ];
+    defaultColors.forEach((color) => {
+      voiceColors.getVoiceColor(color);
+    });
 
-    const wrappedVoices = createListOfWrappedVoices(phrase, 1)
-      .map((html) => html.outerHTML);
+    expect(voiceColors.getVoiceColor('new')).toBeDefined();
+  });
 
-    expect(wrappedVoices).toEqual(expectedPhraseHtml);
+  test('should get the same random color after defaults expire', () => {
+    const firstVoiceColors = new VoiceColors();
+    const secondVoiceColors = new VoiceColors();
+
+    defaultColors.forEach((color) => {
+      firstVoiceColors.getVoiceColor(color);
+      secondVoiceColors.getVoiceColor(color);
+    });
+
+    expect(firstVoiceColors.getVoiceColor('one')).toEqual(secondVoiceColors.getVoiceColor('two'));
   });
 });

--- a/renderers/renderer.css
+++ b/renderers/renderer.css
@@ -1,4 +1,4 @@
-.parent {
+.voice {
   display: flex;
 }
 
@@ -8,29 +8,4 @@
 
 .chart {
   font-family: monospace;
-}
-
-.v1 {
-  display: flex;
-  color: purple;
-}
-
-.v2 {
-  display: flex;
-  color: black;
-}
-
-.c1 {
-  display: flex;
-  color: green;
-}
-
-.c2 {
-  display: flex;
-  color: blue;
-}
-
-.a1 {
-  display: flex;
-  color: red;
 }


### PR DESCRIPTION
Fixes #18 

Remove hardcoded voices from CSS file. Instead, voice classes are added directly to the content div, which allows consumers to customize their voice color if they want.

By default, voices will be randomly colored (with 6 preset values, but we can remove the presets). "Random" color is seeded, so it will consistently be a random order. Package used is here: https://github.com/davidmerfield/randomColor

Also refactored a bit of the test file to make changes a bit easier.