### PR TITLE
Render Chord Diagrams from Fingering Notation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
       "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.6.4.tgz",
       "integrity": "sha512-2rx9IQWnJxD6rx5xjdV7Y8IsdKGkwvkrgXJGfMjolYCcoOMLCFnhQj4VlTKy/1sOnL19XdsWscfdhepltB+MUg==",
       "requires": {
-        "midi": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
+        "midi": "git+https://github.com/paulrosen/MIDI.js.git#abcjs"
       }
     },
     "acorn": {
@@ -1688,7 +1688,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1709,12 +1710,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1729,17 +1732,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1856,7 +1862,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1868,6 +1875,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1882,6 +1890,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1889,12 +1898,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1913,6 +1924,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1993,7 +2005,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2005,6 +2018,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2090,7 +2104,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2126,6 +2141,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2145,6 +2161,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2188,12 +2205,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5116,6 +5135,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg.js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA=="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "license": "ISC",
   "dependencies": {
     "abcjs": "^5.6.4",
-    "randomcolor": "^0.5.4"
+    "randomcolor": "^0.5.4",
+    "svg.js": "^2.7.1"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/renderers/chord_diagram.js
+++ b/renderers/chord_diagram.js
@@ -1,7 +1,17 @@
 'use strict';
 const SVG = require('svg.js');
 
+/** Represents the dimensions of a chord diagram. */
 class ChordBox {
+  /**
+   * Create a ChordBox.
+   * @param {number} x Left most position for drawing.
+   * @param {number} y Right-most position for drawing.
+   * @param {number} width Width of the chord diagram.
+   * @param {number} height Height of the chord diagram.
+   * @param {number} frets Number of frets in the chord diagram.
+   * @param {number} strings Number of strings in the chord diagram.
+   */
   constructor(x, y, width, height, frets, strings) {
     this.x = x;
     this.y = y;
@@ -19,19 +29,40 @@ class ChordBox {
     this.right = this.width - this.stringSpacing * 1.5;
   }
 
+  /**
+   * Gets the X coordinate for the string.
+   * @param {number} i The string index starting from 1.
+   * @return {number} The X coordinate.
+   * */
   string(i) {
     return this.left + i * this.stringSpacing;
   }
 
+  /**
+   * Gets the Y coordinate for the beam. The bridge is beam(0).
+   * @param {number} i The beam index starting from 0.
+   * @return {number} The Y coordinate.
+   * */
   beam(i) {
     return this.header + i * this.fretSpacing;
   }
 
+  /**
+   * Gets the Y coordinate for the fret. Area above the bridge is fret(0).
+   * @param {number} i The fret index starting from 1.
+   * @return {number} The Y coordinate.
+   * */
   fret(i) {
     return this.header + this.fretSpacing / 2 + (i - 1) * this.fretSpacing;
   }
 }
 
+/**
+ * Renders the bridge, frets, strings and string tunings.
+ * @param {SVG.Doc} draw The graphics context.
+ * @param {ChordBox} box The ChordBox dimensions.
+ * @param {string[]} tuning The tuning of the strings.
+ */
 function drawDiagram(draw, box, tuning) {
   // Draw Bridge
   draw.line(box.left, box.header, box.right, box.header).stroke({ width: 2 });
@@ -51,12 +82,25 @@ function drawDiagram(draw, box, tuning) {
   }
 }
 
+/**
+ * Renders a single fingering on a given string and fret.
+ * @param {SVG.Doc} draw The graphics context.
+ * @param {ChordBox} box The ChordBox dimensions.
+ * @param {number} string The string index starting from 1.
+ * @param {number} fret The fret index starting from 1.
+ */
 function drawNote(draw, box, string, fret) {
   draw.circle(box.radius * 2)
     .center(box.string(string - 1), box.fret(fret))
     .fill({ color: '#000' });
 }
 
+/**
+ * Renders a mute symbol above the bridge for the given string.
+ * @param {SVG.Doc} draw The graphics context.
+ * @param {ChordBox} box The ChordBox dimensions.
+ * @param {number} string The string index starting from 1.
+ */
 function drawMute(draw, box, string) {
   const x = box.string(string - 1);
   const y = box.fret(0);
@@ -65,6 +109,14 @@ function drawMute(draw, box, string) {
   draw.line(x-r, y+r, x+r, y-r).stroke({ color: '#000' });
 }
 
+/**
+ * Renders a barre at the given fret across the strings from first to last.
+ * @param {SVG.Doc} draw The graphics context.
+ * @param {ChordBox} box The ChordBox dimensions.
+ * @param {number} first The index of the first string starting from 1.
+ * @param {number} last The index of the last string starting from 1.
+ * @param {number} fret The fret index starting from 1.
+ */
 function drawBarre(draw, box, first, last, fret) {
   const r = box.radius * 0.7;
   const x = (box.string(last - 1) + box.string(first - 1)) / 2;
@@ -74,13 +126,47 @@ function drawBarre(draw, box, first, last, fret) {
     .fill({ color: '#000' });
 }
 
+/**
+ * Renders the fret offset to the right of the first fret. 0 is not rendered.
+ * @param {SVG.Doc} draw The graphics context.
+ * @param {ChordBox} box The ChordBox dimensions.
+ * @param {number} offset The fret offset.
+ */
 function drawFretOffset(draw, box, offset) {
   draw.text(`${offset}fr`)
     .font({ size: box.radius * 2, family: 'Arial' })
     .center((box.right + box.width) / 2, box.fret(1));
 }
 
-function drawChordDiagram(fingering, width=100, height=100,
+/**
+ * Renders a chord diagram.
+ *
+ * Here's an example of fingering object. Note that every key is optional.
+ *
+ * {
+ *   fretOffset: 2,
+ *   mutes: [
+ *     { string: 1 },
+ *     { string: 2 }
+ *   ],
+ *   notes: [
+ *     { string: 3, fret: 3 },
+ *     { string: 4, fret: 5 }
+ *   ],
+ *   barres: [
+ *     { first: 5, last: 6, fret: 6 }
+ *   ]
+ * };
+ *
+ * @param {Object} fingering The fingering object specifying the chord diagram.
+ * @param {number} width The width of the chord diagram.
+ * @param {number} height The height of the chord diagram.
+ * @param {number} frets The number of frets.
+ * @param {number} strings The number of strings.
+ * @param {string[]} tuning The tuning of each string as an array.
+ * @return {string} The rendered chord diagram as SVG.
+ */
+function renderChordDiagram(fingering, width=100, height=100,
   frets=5, strings=6, tuning=['E', 'A', 'D', 'G', 'B', 'e']) {
   const div = window.document.createElement('div');
   const draw = new SVG(div).size(width, height);
@@ -109,5 +195,5 @@ function drawChordDiagram(fingering, width=100, height=100,
 }
 
 module.exports = {
-  drawChordDiagram,
+  renderChordDiagram,
 };

--- a/renderers/chord_diagram.js
+++ b/renderers/chord_diagram.js
@@ -2,22 +2,21 @@
 const SVG = require('svg.js');
 
 class ChordBox {
-  constructor(x, y, w, h, frets, strings) {
-    console.log(w);
+  constructor(x, y, width, height, frets, strings) {
     this.x = x;
     this.y = y;
-    this.w = w;
-    this.h = h;
+    this.width = width;
+    this.height = height;
     this.frets = frets;
     this.strings = strings;
 
-    this.stringSpacing = this.w / (this.strings - 1 + 3);
-    this.fretSpacing = this.h / (this.frets + 2);
-    this.r = Math.min(this.stringSpacing, this.fretSpacing) * 0.35;
+    this.stringSpacing = this.width / (this.strings - 1 + 3);
+    this.fretSpacing = this.height / (this.frets + 2);
+    this.radius = Math.min(this.stringSpacing, this.fretSpacing) * 0.35;
     this.header = this.fretSpacing * 1;
-    this.footer = this.h - this.fretSpacing * 1;
+    this.footer = this.height - this.fretSpacing * 1;
     this.left = this.x + this.stringSpacing * 1.5;
-    this.right = this.w - this.stringSpacing * 1.5;
+    this.right = this.width - this.stringSpacing * 1.5;
   }
 
   getStringX(i) {
@@ -47,13 +46,13 @@ function drawDiagram(draw, box, tuning) {
   for (let i = 0; i < box.strings; i++) {
     const x = box.getStringX(i);
     draw.line(x, box.header, x, box.footer).stroke({ color: '#000' });
-    draw.text(tuning[i]).font({ size: box.r * 2, family: 'Arial' })
-      .center(x, (box.footer + box.h) / 2);
+    draw.text(tuning[i]).font({ size: box.radius * 2, family: 'Arial' })
+      .center(x, (box.footer + box.height) / 2);
   }
 }
 
 function drawNote(draw, box, string, fret) {
-  draw.circle(box.r * 2)
+  draw.circle(box.radius * 2)
     .center(box.getStringX(string - 1), box.getFretY(fret))
     .fill({ color: '#000' });
 }
@@ -61,13 +60,13 @@ function drawNote(draw, box, string, fret) {
 function drawMute(draw, box, string) {
   const x = box.getStringX(string - 1);
   const y = box.getFretY(0);
-  const r = box.r * 0.7;
+  const r = box.radius * 0.7;
   draw.line(x-r, y-r, x+r, y+r).stroke({ color: '#000' });
   draw.line(x-r, y+r, x+r, y-r).stroke({ color: '#000' });
 }
 
 function drawBarre(draw, box, first, last, fret) {
-  const r = box.r * 0.7;
+  const r = box.radius * 0.7;
   const x = (box.getStringX(last - 1) + box.getStringX(first - 1)) / 2;
   const w = box.getStringX(last - 1) - box.getStringX(first - 1) + 2 * r;
   draw.rect(w, 2 * r)
@@ -77,8 +76,8 @@ function drawBarre(draw, box, first, last, fret) {
 
 function drawFretOffset(draw, box, offset) {
   draw.text(`${offset}fr`)
-    .font({ size: box.r * 2, family: 'Arial' })
-    .center((box.right + box.w) / 2, box.getFretY(1));
+    .font({ size: box.radius * 2, family: 'Arial' })
+    .center((box.right + box.width) / 2, box.getFretY(1));
 }
 
 function drawChordDiagram(fingering, width=100, height=100,

--- a/renderers/chord_diagram.js
+++ b/renderers/chord_diagram.js
@@ -19,15 +19,15 @@ class ChordBox {
     this.right = this.width - this.stringSpacing * 1.5;
   }
 
-  getStringX(i) {
+  string(i) {
     return this.left + i * this.stringSpacing;
   }
 
-  getBeamY(i) {
+  beam(i) {
     return this.header + i * this.fretSpacing;
   }
 
-  getFretY(i) {
+  fret(i) {
     return this.header + this.fretSpacing / 2 + (i - 1) * this.fretSpacing;
   }
 }
@@ -38,13 +38,13 @@ function drawDiagram(draw, box, tuning) {
 
   // Draw Frets
   for (let i = 1; i <= box.frets; i++) {
-    const y = box.getBeamY(i);
+    const y = box.beam(i);
     draw.line(box.left, y, box.right, y).stroke({ color: '#999' });
   }
 
   // Draw Strings and Tuning
   for (let i = 0; i < box.strings; i++) {
-    const x = box.getStringX(i);
+    const x = box.string(i);
     draw.line(x, box.header, x, box.footer).stroke({ color: '#000' });
     draw.text(tuning[i]).font({ size: box.radius * 2, family: 'Arial' })
       .center(x, (box.footer + box.height) / 2);
@@ -53,13 +53,13 @@ function drawDiagram(draw, box, tuning) {
 
 function drawNote(draw, box, string, fret) {
   draw.circle(box.radius * 2)
-    .center(box.getStringX(string - 1), box.getFretY(fret))
+    .center(box.string(string - 1), box.fret(fret))
     .fill({ color: '#000' });
 }
 
 function drawMute(draw, box, string) {
-  const x = box.getStringX(string - 1);
-  const y = box.getFretY(0);
+  const x = box.string(string - 1);
+  const y = box.fret(0);
   const r = box.radius * 0.7;
   draw.line(x-r, y-r, x+r, y+r).stroke({ color: '#000' });
   draw.line(x-r, y+r, x+r, y-r).stroke({ color: '#000' });
@@ -67,17 +67,17 @@ function drawMute(draw, box, string) {
 
 function drawBarre(draw, box, first, last, fret) {
   const r = box.radius * 0.7;
-  const x = (box.getStringX(last - 1) + box.getStringX(first - 1)) / 2;
-  const w = box.getStringX(last - 1) - box.getStringX(first - 1) + 2 * r;
+  const x = (box.string(last - 1) + box.string(first - 1)) / 2;
+  const w = box.string(last - 1) - box.string(first - 1) + 2 * r;
   draw.rect(w, 2 * r)
-    .center(x, box.getFretY(fret)).radius(r)
+    .center(x, box.fret(fret)).radius(r)
     .fill({ color: '#000' });
 }
 
 function drawFretOffset(draw, box, offset) {
   draw.text(`${offset}fr`)
     .font({ size: box.radius * 2, family: 'Arial' })
-    .center((box.right + box.width) / 2, box.getFretY(1));
+    .center((box.right + box.width) / 2, box.fret(1));
 }
 
 function drawChordDiagram(fingering, width=100, height=100,

--- a/renderers/chord_diagram.js
+++ b/renderers/chord_diagram.js
@@ -1,0 +1,114 @@
+'use strict';
+const SVG = require('svg.js');
+
+class ChordBox {
+  constructor(x, y, w, h, frets, strings) {
+    console.log(w);
+    this.x = x;
+    this.y = y;
+    this.w = w;
+    this.h = h;
+    this.frets = frets;
+    this.strings = strings;
+
+    this.stringSpacing = this.w / (this.strings - 1 + 3);
+    this.fretSpacing = this.h / (this.frets + 2);
+    this.r = Math.min(this.stringSpacing, this.fretSpacing) * 0.35;
+    this.header = this.fretSpacing * 1;
+    this.footer = this.h - this.fretSpacing * 1;
+    this.left = this.x + this.stringSpacing * 1.5;
+    this.right = this.w - this.stringSpacing * 1.5;
+  }
+
+  getStringX(i) {
+    return this.left + i * this.stringSpacing;
+  }
+
+  getBeamY(i) {
+    return this.header + i * this.fretSpacing;
+  }
+
+  getFretY(i) {
+    return this.header + this.fretSpacing / 2 + (i - 1) * this.fretSpacing;
+  }
+}
+
+function drawDiagram(draw, box, tuning) {
+  // Draw Bridge
+  draw.line(box.left, box.header, box.right, box.header).stroke({ width: 2 });
+
+  // Draw Frets
+  for (let i = 1; i <= box.frets; i++) {
+    const y = box.getBeamY(i);
+    draw.line(box.left, y, box.right, y).stroke({ color: '#999' });
+  }
+
+  // Draw Strings and Tuning
+  for (let i = 0; i < box.strings; i++) {
+    const x = box.getStringX(i);
+    draw.line(x, box.header, x, box.footer).stroke({ color: '#000' });
+    draw.text(tuning[i]).font({ size: box.r * 2, family: 'Arial' })
+      .center(x, (box.footer + box.h) / 2);
+  }
+}
+
+function drawNote(draw, box, string, fret) {
+  draw.circle(box.r * 2)
+    .center(box.getStringX(string - 1), box.getFretY(fret))
+    .fill({ color: '#000' });
+}
+
+function drawMute(draw, box, string) {
+  const x = box.getStringX(string - 1);
+  const y = box.getFretY(0);
+  const r = box.r * 0.7;
+  draw.line(x-r, y-r, x+r, y+r).stroke({ color: '#000' });
+  draw.line(x-r, y+r, x+r, y-r).stroke({ color: '#000' });
+}
+
+function drawBarre(draw, box, first, last, fret) {
+  const r = box.r * 0.7;
+  const x = (box.getStringX(last - 1) + box.getStringX(first - 1)) / 2;
+  const w = box.getStringX(last - 1) - box.getStringX(first - 1) + 2 * r;
+  draw.rect(w, 2 * r)
+    .center(x, box.getFretY(fret)).radius(r)
+    .fill({ color: '#000' });
+}
+
+function drawFretOffset(draw, box, offset) {
+  draw.text(`${offset}fr`)
+    .font({ size: box.r * 2, family: 'Arial' })
+    .center((box.right + box.w) / 2, box.getFretY(1));
+}
+
+function drawChordDiagram(fingering, width=100, height=100,
+  frets=5, strings=6, tuning=['E', 'A', 'D', 'G', 'B', 'e']) {
+  const div = window.document.createElement('div');
+  const draw = new SVG(div).size(width, height);
+  const box = new ChordBox(0, 0, width, height, frets, strings);
+
+  drawDiagram(draw, box, tuning);
+
+  const fretOffset = fingering.fretOffset || 0;
+  if (fretOffset > 0) {
+    drawFretOffset(draw, box, fretOffset);
+  }
+
+  for (const { string } of fingering.mutes || []) {
+    drawMute(draw, box, string);
+  }
+
+  for (const { string, fret } of fingering.notes || []) {
+    drawNote(draw, box, string, fret - fretOffset);
+  }
+
+  for (const { first, last, fret } of fingering.barres || []) {
+    drawBarre(draw, box, first, last, fret - fretOffset);
+  }
+
+  return div.innerHTML;
+}
+
+module.exports = {
+  drawChordDiagram,
+};


### PR DESCRIPTION
This PR provides a function for rendering Chord Diagrams using SVG.js. Given fingering notation such as:

```
fingering = {
  fretOffset: 2,
  mutes: [
    { string: 1 },
    { string: 2 }
  ],
  notes: [
    { string: 3, fret: 3 },
    { string: 4, fret: 5 }
  ],
  barres: [
    { first: 5, last: 6, fret: 6 }
  ]
};
```

Calling: `drawChordDiagram(fingering, 200, 200)` will render:

<img src="https://user-images.githubusercontent.com/361429/53394606-a46aa780-3954-11e9-8570-7562e3734b5c.png" alt="Chord Diagram" width="170" height="198" />