### PR TITLE
Memoize the chord diagram renderer and inline error message in rendered markdown.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function MarkdownMusic(md, musicOpts) {
         try {
           return md.highlightRegistry[lang](str, md.musicOpts);
         } catch (error) {
-          return `<div class="error">${error}</div>`;
+          return `<pre>${str}</pre><div class="error">${error}</div>`;
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,11 @@ function MarkdownMusic(md, musicOpts) {
   md.set({
     highlight: function(str, lang) {
       if (md.highlightRegistry.hasOwnProperty(lang)) {
-        return md.highlightRegistry[lang](str, md.musicOpts);
+        try {
+          return md.highlightRegistry[lang](str, md.musicOpts);
+        } catch (error) {
+          return `<div class="error">${error}</div>`;
+        }
       }
     }
   });

--- a/renderers/chord_diagram.js
+++ b/renderers/chord_diagram.js
@@ -1,6 +1,8 @@
 'use strict';
 const SVG = require('svg.js');
 
+const cache = new Map();
+
 /** Represents the dimensions of a chord diagram. */
 class ChordBox {
   /**
@@ -204,6 +206,12 @@ function parseShorthand(shorthand) {
  */
 function renderChordDiagram(shorthand, width=100, height=100,
   frets=5, tuning=['E', 'A', 'D', 'G', 'B', 'e']) {
+  const cacheKey = (`${shorthand}, width=${width}, height=${height}, ` +
+    `frets=${frets}, tuning=${tuning.toString()}`);
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey);
+  }
+
   const fingering = parseShorthand(shorthand);
   const strings = tuning.length;
   const div = window.document.createElement('div');
@@ -228,6 +236,7 @@ function renderChordDiagram(shorthand, width=100, height=100,
     drawBarre(draw, box, first, last, fret - fingering.offset + 1);
   }
 
+  cache.set(cacheKey, div.innerHTML);
   return div.innerHTML;
 }
 


### PR DESCRIPTION
This PR memoizes the chord diagram renderer to improve performance. If the chord diagram renderer is called with the same arguments as a previous call, the originally produced SVG will be cached and returned.

![inline-error](https://user-images.githubusercontent.com/361429/53689323-e22a5000-3d07-11e9-8487-bbdeed166cc3.gif)

Fixes #32 and #34 