### PR TITLE
Convert ASCII Tab to Markdown Music

### DIFF
--- a/converters/asciitab.js
+++ b/converters/asciitab.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+'use strict';
+
+const Chord = require('../parsers/chord.js');
+
+const State = {
+  DEFAULT: 1,
+  VERSE: 2
+};
+
+function getMaybeHeading(line) {
+  if (line.endsWith(':')) {
+    return `## ${line.slice(0, -1)}`;
+  }
+
+  if (line.startsWith('[') && line.endsWith(']')) {
+    return `## ${line.slice(1, -1)}`;
+  }
+
+  return null;
+}
+
+function getMaybeChords(line) {
+  const tokens = line.trim().split(/\s+/);
+
+  for (const token of tokens) {
+    if (!Chord.isChord(token)) {
+      return null;
+    }
+  }
+
+  return `c1: ${line}`;
+}
+
+function convert(input) {
+  let state = State.DEFAULT;
+  let voiceIndex = 1;
+  const lines = input.split(/\n/);
+  const output = [];
+
+  for (const line of lines) {
+    if (state === State.DEFAULT) {
+      const maybeHeading = getMaybeHeading(line);
+      if (maybeHeading) {
+        output.push(maybeHeading);
+        continue;
+      }
+
+      const maybeChords = getMaybeChords(line);
+      if (maybeChords) {
+        state = State.VERSE;
+        output.push('```chords');
+        output.push(maybeChords);
+        voiceIndex = 1;
+        continue;
+      }
+
+      output.push(line);
+      continue;
+    }
+
+    if (state === State.VERSE) {
+      const maybeHeading = getMaybeHeading(line);
+      if (maybeHeading) {
+        state = State.DEFAULT;
+        output.push('```');
+        output.push('');
+        output.push(maybeHeading);
+        continue;
+      }
+
+      const maybeChords = getMaybeChords(line);
+      if (maybeChords) {
+        output.push('');
+        output.push(maybeChords);
+        voiceIndex = 1;
+        continue;
+      }
+
+      if (line.trim() === '') {
+        continue;
+      }
+
+      output.push(`l${voiceIndex}: ${line}`);
+      voiceIndex += 1;
+      continue;
+    }
+  }
+
+  if (state === State.VERSE) {
+    output.push('```');
+  }
+
+  return output.join('\n');
+}
+
+async function read(stream) {
+  let buffer = Buffer.alloc(0);
+  for await (const chunk of stream) {
+    buffer = Buffer.concat([buffer, chunk]);
+  }
+  return buffer.toString('utf8');
+}
+
+async function main() {
+  console.log(convert(await read(process.stdin)));
+}
+
+if (typeof require != 'undefined' && require.main == module) {
+  main();
+}
+
+module.exports = {
+  convert
+};

--- a/converters/asciitab.spec.js
+++ b/converters/asciitab.spec.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const { convert } = require('./asciitab.js');
+
+describe('ASCII Tab Converter transforms', () => {
+  test('two phrase verse', () => {
+    const actual = convert([
+      '                   Am     G  F          G      Esus4  E',
+      'All the leaves are brown        and the sky is gray',
+      'F               C     E  Am       F        Esus4  E',
+      `I've been for a walk         on a winter's day`
+    ].join('\n'));
+
+    const expected = [
+      '```chords',
+      'c1:                    Am     G  F          G      Esus4  E',
+      'l1: All the leaves are brown        and the sky is gray',
+      '',
+      'c1: F               C     E  Am       F        Esus4  E',
+      `l1: I've been for a walk         on a winter's day`,
+      '```'
+    ].join('\n');
+
+    expect(actual).toEqual(expected);
+  });
+
+  test('single phrase verse with two voices', () => {
+    const actual = convert([
+      'Am                    G       Am',
+      'Tell her to make me a cambric shirt',
+      '                    On the side of a hill in the deep forest green'
+    ].join('\n'));
+
+    const expected = [
+      '```chords',
+      'c1: Am                    G       Am',
+      'l1: Tell her to make me a cambric shirt',
+      'l2:                     On the side of a hill in the deep forest green',
+      '```'
+    ].join('\n');
+
+    expect(actual).toEqual(expected);
+  });
+
+  test('headers ending with :', () => {
+    const actual = convert('Verse 1:');
+    expect(actual).toEqual('## Verse 1');
+  });
+
+  test('headers contained in []', () => {
+    const actual = convert('[Verse 1]');
+    expect(actual).toEqual('## Verse 1');
+  });
+
+  test('header following a verse', () => {
+    const actual = convert([
+      '                   Am     G  F          G      Esus4  E',
+      'All the leaves are brown        and the sky is gray',
+      '',
+      'Verse 2:'
+    ].join('\n'));
+
+    const expected = [
+      '```chords',
+      'c1:                    Am     G  F          G      Esus4  E',
+      'l1: All the leaves are brown        and the sky is gray',
+      '```',
+      '',
+      '## Verse 2'
+    ].join('\n');
+
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
This PR introduces a script that can be used either from the command line or the browser to convert an ASCII Tab file to Markdown Music. There will be a lot of room for improvement on this script. Right now, it recognizes the following:

1. Headings such as 'Verse 1:' or '[Verse 1]'
1. Verses with a chord line and one or more lyric lines

Fixes #13 