### PR TITLE
Convert verses to events, initial impl

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
         "indent": ["error", 2, {
             "MemberExpression": 1
         }],
-        "object-curly-spacing": ["error", "always"]
+        "object-curly-spacing": ["error", "always"],
+        "no-debugger": 2
     }
 }

--- a/parsers/events.js
+++ b/parsers/events.js
@@ -1,0 +1,106 @@
+'use strict';
+
+let addedCharacters = 0;
+
+function splitPreviousEvent(previousEvent, voicesAddedToEvent, eventIndex) {
+  const voicesToAdd = [];
+
+  let hasAddedCharacter = false;
+  // Split any previous events
+  previousEvent.forEach((voice) => {
+    if (voicesAddedToEvent.indexOf(voice.voice) === -1 &&
+        eventIndex < voice.index + voice.content.toString().length) {
+      // Split voice from previous event, add remainder to this event.
+      const splitIndex = eventIndex - voice.index + addedCharacters;
+      const event = {
+        index: eventIndex + addedCharacters,
+        voice: voice.voice,
+        content: `-${voice.content.substring(splitIndex)}`
+      };
+      voice.content = voice.content.substring(0, splitIndex);
+
+      voicesToAdd.push(event);
+
+      // Update index position to account for added character.
+      if (!hasAddedCharacter) {
+        addedCharacters++;
+        hasAddedCharacter = true;
+      }
+    }
+  });
+
+  return voicesToAdd;
+}
+
+function addEvents(verse, longestEvent) {
+  const voices = [];
+  const voicesAdded = [];
+
+  verse.forEach((events, voiceName) => {
+    if (events.length === 0) {
+      return;
+    }
+
+    const event = events[0];
+    // Only include an event if it falls between the longest event's start and end index.
+    if (longestEvent.index <= event.index &&
+        event.index < longestEvent.index + longestEvent.content.toString().length) {
+      const eventToAdd = events.shift();
+      eventToAdd.voice = voiceName;
+      eventToAdd.index += addedCharacters;
+      voices.push(eventToAdd);
+      voicesAdded.push(voiceName);
+    }
+  });
+
+  return { voicesAdded, voices };
+}
+
+function createEventFromVerse(verse, voiceOrder, previousEvent = []) {
+  const firstEventOfEachVoice = Array.from(verse.values()).map((voiceArr) => voiceArr[0]);
+
+  // Find the minimum index of all voices, since we want to parse events in the order they happen.
+  const eventIndex = firstEventOfEachVoice.reduce((acc, voice) => {
+    return !voice || voice.index >= acc ? acc : voice.index;
+  }, Number.MAX_SAFE_INTEGER);
+
+  // Find the longest event so we know the maximum length of this event.
+  const longestEvent = firstEventOfEachVoice.reduce((acc, voice) => {
+    if (!voice || voice.index > eventIndex) {
+      return acc;
+    }
+
+    if (!acc || voice.content.toString().length > acc.content.toString().length) {
+      return voice;
+    }
+
+    return acc;
+  }, undefined);
+
+  const { voicesAdded, voices } = addEvents(verse, longestEvent);
+
+  return voices.concat(splitPreviousEvent(previousEvent, voicesAdded, eventIndex))
+    .sort((voice1, voice2) => voiceOrder.indexOf(voice1.voice) - voiceOrder.indexOf(voice2.voice));
+}
+
+function convertVersesToEvents(verses) {
+  return verses.map((verse) => {
+    // Deep copy the verse so that we don't remove everything from the original.
+    const verseCopy = new Map(verse);
+    const voiceOrder = Array.from(verseCopy.keys());
+    const events = [];
+
+    // create events for this verse until there are no events left to process.
+    let eventList = [];
+    while (!Array.from(verseCopy.values()).every((arr) => arr.length === 0)) {
+      eventList = createEventFromVerse(verseCopy, voiceOrder, eventList);
+      events.push(eventList);
+    }
+
+    return events;
+  });
+}
+
+module.exports = {
+  convertVersesToEvents
+};

--- a/parsers/events.js
+++ b/parsers/events.js
@@ -1,100 +1,149 @@
 'use strict';
 
-let addedCharacters = 0;
+/**
+ * Represents a list of events that occur during a phrase.
+ *
+ * An event is a list of voice objects (index, content, and name) that occur in the same block of space.
+ *
+ * See tests for example input/output structure.
+ */
+class EventList {
+  constructor() {
+    this.addedCharacters = 0;
+    this.previousEventList = [];
+  }
 
-function splitPreviousEvent(previousEvent, voicesAddedToEvent, eventIndex) {
-  const voicesToAdd = [];
+  /**
+   * Splits any events from the previous event list that overflow into the current event.
+   *
+   * For example, if a previous event is { index: 0, content: 'Wonderful' }, and the current event list begins at
+   * index 5, this will split the previous event to { index: 0, content: 'Wonder' }
+   * and return { index: 5, content: '-ful' } as part of the list of voices to add to the current event list.
+   *
+   * @param {String[]} voicesAddedToEvent The voice names that have already been added to the event list.
+   * @param {number} eventIndex The start index of the current event list.
+   * @return {Object[]} The list of voice events to add to the event list.
+   */
+  splitPreviousEvent(voicesAddedToEvent, eventIndex) {
+    const voicesToAdd = [];
 
-  let hasAddedCharacter = false;
-  // Split any previous events
-  previousEvent.forEach((voice) => {
-    if (voicesAddedToEvent.indexOf(voice.voice) === -1 &&
-        eventIndex < voice.index + voice.content.toString().length) {
-      // Split voice from previous event, add remainder to this event.
-      const splitIndex = eventIndex - voice.index + addedCharacters;
-      const event = {
-        index: eventIndex + addedCharacters,
-        voice: voice.voice,
-        content: `-${voice.content.substring(splitIndex)}`
-      };
-      voice.content = voice.content.substring(0, splitIndex);
+    let hasAddedCharacter = false;
+    // Split any previous events
+    this.previousEventList.forEach((voice) => {
+      if (voicesAddedToEvent.indexOf(voice.voice) === -1 &&
+          eventIndex < voice.index + voice.content.toString().length) {
+        debugger;
+        // Split voice from previous event, add remainder to this event.
+        const splitIndex = eventIndex - voice.index + this.addedCharacters;
+        const event = {
+          index: eventIndex + this.addedCharacters,
+          voice: voice.voice,
+          content: `-${voice.content.substring(splitIndex)}`
+        };
+        voice.content = voice.content.substring(0, splitIndex);
 
-      voicesToAdd.push(event);
+        voicesToAdd.push(event);
 
-      // Update index position to account for added character.
-      if (!hasAddedCharacter) {
-        addedCharacters++;
-        hasAddedCharacter = true;
+        // Update index position to account for added character.
+        if (!hasAddedCharacter) {
+          this.addedCharacters++;
+          hasAddedCharacter = true;
+        }
       }
-    }
-  });
+    });
 
-  return voicesToAdd;
+    return voicesToAdd;
+  }
+
+  /**
+   * Adds one of each voice from a phrase whose content fits within the bounds of the longest event.
+   *
+   * To fit within the bounds, a voice event must start (voice.index) between the longest event's index and
+   * the longest event's index + content length. If an voice event does not fit, that voice is skipped for this event.
+   *
+   * @param {Map<String, Object[]>} phrase The phrase to pick events from.
+   * @param {Object} longestEvent The longest (by content length) and first voice event from phrase.
+   * @return {String[]} voiceAdded Voice names added to event list.
+   * @return {Object[]} eventList List of the first of each voice from phrase that fit within bounds of longest event.
+   */
+  addEvents(phrase, longestEvent) {
+    const eventList = [];
+    const voicesAdded = [];
+
+    phrase.forEach((events, voiceName) => {
+      if (events.length === 0) {
+        return;
+      }
+
+      const event = events[0];
+      // Only include an event if it falls between the longest event's start and end index.
+      if (longestEvent.index <= event.index &&
+          event.index < longestEvent.index + longestEvent.content.toString().length) {
+        const eventToAdd = events.shift();
+        eventToAdd.voice = voiceName;
+        eventToAdd.index += this.addedCharacters;
+        eventList.push(eventToAdd);
+        voicesAdded.push(voiceName);
+      }
+    });
+
+    return { voicesAdded, eventList };
+  }
+
+  /**
+   * Creates a list of events from given phrase.
+   *
+   * @param {Map<String, Object[]>} phrase Map of voice names to voice object stack.
+   * @param {String[]} voiceOrder Sort order for voices.
+   * @return {Object[]} List of event lists sorted (by voiceOrder).
+   */
+  createEventListFromPhrase(phrase, voiceOrder) {
+    const firstEventOfEachVoice = Array.from(phrase.values()).map((voiceArr) => voiceArr[0]);
+
+    // Find the minimum index of all voices, since we want to parse events in the order they happen.
+    const eventIndex = firstEventOfEachVoice.reduce((minimumIndex, voice) => {
+      return !voice || voice.index >= minimumIndex ? minimumIndex : voice.index;
+    }, Number.MAX_SAFE_INTEGER);
+
+    // Find the longest event so we know the maximum length of this event.
+    const longestEvent = firstEventOfEachVoice.reduce((currentLongestEvent, voice) => {
+      if (!voice || voice.index > eventIndex) {
+        return currentLongestEvent;
+      }
+
+      if (!currentLongestEvent || voice.content.toString().length > currentLongestEvent.content.toString().length) {
+        return voice;
+      }
+
+      return currentLongestEvent;
+    }, undefined);
+
+    const { voicesAdded, eventList } = this.addEvents(phrase, longestEvent);
+
+    this.previousEventList = eventList.concat(this.splitPreviousEvent(voicesAdded, eventIndex))
+      .sort((voice1, voice2) => voiceOrder.indexOf(voice1.voice) - voiceOrder.indexOf(voice2.voice));
+
+    return this.previousEventList;
+  }
 }
 
-function addEvents(verse, longestEvent) {
-  const voices = [];
-  const voicesAdded = [];
-
-  verse.forEach((events, voiceName) => {
-    if (events.length === 0) {
-      return;
-    }
-
-    const event = events[0];
-    // Only include an event if it falls between the longest event's start and end index.
-    if (longestEvent.index <= event.index &&
-        event.index < longestEvent.index + longestEvent.content.toString().length) {
-      const eventToAdd = events.shift();
-      eventToAdd.voice = voiceName;
-      eventToAdd.index += addedCharacters;
-      voices.push(eventToAdd);
-      voicesAdded.push(voiceName);
-    }
-  });
-
-  return { voicesAdded, voices };
-}
-
-function createEventFromVerse(verse, voiceOrder, previousEvent = []) {
-  const firstEventOfEachVoice = Array.from(verse.values()).map((voiceArr) => voiceArr[0]);
-
-  // Find the minimum index of all voices, since we want to parse events in the order they happen.
-  const eventIndex = firstEventOfEachVoice.reduce((acc, voice) => {
-    return !voice || voice.index >= acc ? acc : voice.index;
-  }, Number.MAX_SAFE_INTEGER);
-
-  // Find the longest event so we know the maximum length of this event.
-  const longestEvent = firstEventOfEachVoice.reduce((acc, voice) => {
-    if (!voice || voice.index > eventIndex) {
-      return acc;
-    }
-
-    if (!acc || voice.content.toString().length > acc.content.toString().length) {
-      return voice;
-    }
-
-    return acc;
-  }, undefined);
-
-  const { voicesAdded, voices } = addEvents(verse, longestEvent);
-
-  return voices.concat(splitPreviousEvent(previousEvent, voicesAdded, eventIndex))
-    .sort((voice1, voice2) => voiceOrder.indexOf(voice1.voice) - voiceOrder.indexOf(voice2.voice));
-}
-
-function convertVersesToEvents(verses) {
-  return verses.map((verse) => {
-    // Deep copy the verse so that we don't remove everything from the original.
-    const verseCopy = new Map(verse);
-    const voiceOrder = Array.from(verseCopy.keys());
+/**
+ * Converts a verse to list of event lists.
+ *
+ * @param {Object} verse The verse that contains phrases to be translated to events.
+ * @return {EventList[]} List of EventList that represent a verse. Each phrase is represented by a single EventList.
+ */
+function convertVerseToEvents(verse) {
+  return verse.map((phrase) => {
+    // Deep copy the phrase so that we don't remove everything from the original.
+    const phraseCopy = new Map(phrase);
+    const voiceOrder = Array.from(phraseCopy.keys());
     const events = [];
 
-    // create events for this verse until there are no events left to process.
-    let eventList = [];
-    while (!Array.from(verseCopy.values()).every((arr) => arr.length === 0)) {
-      eventList = createEventFromVerse(verseCopy, voiceOrder, eventList);
-      events.push(eventList);
+    // create events for this phrase until there are no events left to process.
+    const eventList = new EventList();
+    while (!Array.from(phraseCopy.values()).every((arr) => arr.length === 0)) {
+      events.push(eventList.createEventListFromPhrase(phraseCopy, voiceOrder));
     }
 
     return events;
@@ -102,5 +151,5 @@ function convertVersesToEvents(verses) {
 }
 
 module.exports = {
-  convertVersesToEvents
+  convertVerseToEvents
 };

--- a/parsers/events.js
+++ b/parsers/events.js
@@ -32,7 +32,7 @@ class EventList {
     this.previousEventList.forEach((voice) => {
       if (voicesAddedToEvent.indexOf(voice.voice) === -1 &&
           eventIndex < voice.index + voice.content.toString().length) {
-        debugger;
+
         // Split voice from previous event, add remainder to this event.
         const splitIndex = eventIndex - voice.index + this.addedCharacters;
         const event = {
@@ -135,7 +135,8 @@ class EventList {
  */
 function convertVerseToEvents(verse) {
   return verse.map((phrase) => {
-    // Deep copy the phrase so that we don't remove everything from the original.
+    // TODO: This is meant to deep copy the phrase map so we don't remove from the array.
+    // This is a shallow copy, and does not actually deep copy the array values.
     const phraseCopy = new Map(phrase);
     const voiceOrder = Array.from(phraseCopy.keys());
     const events = [];

--- a/parsers/events.js
+++ b/parsers/events.js
@@ -32,7 +32,6 @@ class EventList {
     this.previousEventList.forEach((voice) => {
       if (voicesAddedToEvent.indexOf(voice.voice) === -1 &&
           eventIndex < voice.index + voice.content.toString().length) {
-
         // Split voice from previous event, add remainder to this event.
         const splitIndex = eventIndex - voice.index + this.addedCharacters;
         const event = {

--- a/parsers/events.spec.js
+++ b/parsers/events.spec.js
@@ -4,8 +4,8 @@ const rewire = require('rewire');
 const Chord = require('./chord.js');
 const eventsjs = rewire('./events.js');
 
-const createEventFromVerse = eventsjs.__get__('createEventFromVerse');
-const convertVersesToEvents = eventsjs.__get__('convertVersesToEvents');
+const convertVerseToEvents = eventsjs.__get__('convertVerseToEvents');
+const EventList = eventsjs.__get__('EventList');
 
 describe('Event', () => {
   test('should add voices', () => {
@@ -31,7 +31,8 @@ describe('Event', () => {
       ]]
     ]);
 
-    const actualEvent = createEventFromVerse(nextVoices, ['c1', 'c2', 'l1', 'a1']);
+    const eventList = new EventList();
+    const actualEvent = eventList.createEventListFromPhrase(nextVoices, ['c1', 'c2', 'l1', 'a1']);
 
     expect(actualEvent).toEqual(expectedEvent);
   });
@@ -57,7 +58,8 @@ describe('Event', () => {
       { index: 0, voice: 'l2', content: 'Test' }
     ];
 
-    const actualEvent = createEventFromVerse(nextVoices, ['c1', 'c2', 'l1', 'l2']);
+    const eventList = new EventList();
+    const actualEvent = eventList.createEventListFromPhrase(nextVoices, ['c1', 'c2', 'l1', 'l2']);
 
     expect(actualEvent).toEqual(expectedEvent);
   });
@@ -83,7 +85,8 @@ describe('Event', () => {
       { index: 0, voice: 'l1', content: 'The' }
     ];
 
-    const actualEvent = createEventFromVerse(nextVoices, ['c1', 'c2', 'l1', 'l2']);
+    const eventList = new EventList();
+    const actualEvent = eventList.createEventListFromPhrase(nextVoices, ['c1', 'c2', 'l1', 'l2']);
 
     expect(actualEvent).toEqual(expectedEvent);
   });
@@ -149,12 +152,12 @@ describe('Event', () => {
       ]
     ];
 
-    const actualEventList = convertVersesToEvents(verse);
+    const actualEventList = convertVerseToEvents(verse);
     expect(actualEventList).toEqual(expectedEvents);
   });
 
   test('should split a previous event if there is overlap', () => {
-    const verses = [
+    const verse = [
       new Map([[
         'c1', [
           { index: 0, content: new Chord('A') },
@@ -194,7 +197,45 @@ describe('Event', () => {
       ]
     ];
 
-    const actualEventList = convertVersesToEvents(verses);
+    const actualEventList = convertVerseToEvents(verse);
+
+    expect(actualEventList).toEqual(expectedEventList);
+  });
+
+  test('should split all previous events when long events exist in different phrases', () => {
+    const verse = [
+      new Map([[
+        'c1', [
+          { index: 0, content: new Chord('Am') },
+          { index: 6, content: new Chord('C') },
+        ]], [
+        'l1', [
+          { index: 0, content: 'Wonderful' }
+        ]]
+      ]),
+      new Map([[
+        'c1', [
+          { index: 0, content: new Chord('Am') },
+          { index: 4, content: new Chord('C') },
+        ]], [
+        'l1', [
+          { index: 0, content: 'Testing' }
+        ]]
+      ]),
+    ];
+
+    const expectedEventList = [
+      [
+        [{ index: 0, voice: 'c1', content: new Chord('Am') }, { index: 0, voice: 'l1', content: 'Wonder' }],
+        [{ index: 6, voice: 'c1', content: new Chord('C') }, { index: 6, voice: 'l1', content: '-ful' }]
+      ],
+      [
+        [{ index: 0, voice: 'c1', content: new Chord('Am') }, { index: 0, voice: 'l1', content: 'Test' }],
+        [{ index: 4, voice: 'c1', content: new Chord('C') }, { index: 4, voice: 'l1', content: '-ing' }]
+      ]
+    ];
+
+    const actualEventList = convertVerseToEvents(verse);
 
     expect(actualEventList).toEqual(expectedEventList);
   });

--- a/parsers/events.spec.js
+++ b/parsers/events.spec.js
@@ -1,0 +1,201 @@
+'use strict';
+
+const rewire = require('rewire');
+const Chord = require('./chord.js');
+const eventsjs = rewire('./events.js');
+
+const createEventFromVerse = eventsjs.__get__('createEventFromVerse');
+const convertVersesToEvents = eventsjs.__get__('convertVersesToEvents');
+
+describe('Event', () => {
+  test('should add voices', () => {
+    const expectedEvent = [
+      { index: 4, voice: 'c1', content: 'G' },
+      { index: 4, voice: 'c2', content: 'C' },
+      { index: 4, voice: 'l1', content: 'longest' },
+      { index: 4, voice: 'a1', content: 'crash!' },
+    ];
+
+    const nextVoices = new Map([[
+      'c1', [
+        { index: 4, content: 'G' },
+      ]], [
+      'c2', [
+        { index: 4, content: 'C' },
+      ]], [
+      'l1', [
+        { index: 4, content: 'longest' },
+      ]], [
+      'a1', [
+        { index: 4, content: 'crash!' },
+      ]]
+    ]);
+
+    const actualEvent = createEventFromVerse(nextVoices, ['c1', 'c2', 'l1', 'a1']);
+
+    expect(actualEvent).toEqual(expectedEvent);
+  });
+
+  test('should only add voices that are in index range', () => {
+    const nextVoices = new Map([[
+      'c1', [
+        { index: 4, content: 'G' },
+      ]], [
+      'c2', [
+        { index: 4, content: 'C' },
+      ]], [
+      'l1', [
+        { index: 0, content: 'The' },
+      ]], [
+      'l2', [
+        { index: 0, content: 'Test' },
+      ]]
+    ]);
+
+    const expectedEvent = [
+      { index: 0, voice: 'l1', content: 'The' },
+      { index: 0, voice: 'l2', content: 'Test' }
+    ];
+
+    const actualEvent = createEventFromVerse(nextVoices, ['c1', 'c2', 'l1', 'l2']);
+
+    expect(actualEvent).toEqual(expectedEvent);
+  });
+
+  test('should add next index first', () => {
+    const nextVoices = new Map([[
+      'c1', [
+        { index: 0, content: 'G' },
+      ]], [
+      'c2', [
+        { index: 40, content: 'C' },
+      ]], [
+      'l1', [
+        { index: 0, content: 'The' },
+      ]], [
+      'l2', [
+        { index: 40, content: 'Test' },
+      ]]
+    ]);
+
+    const expectedEvent = [
+      { index: 0, voice: 'c1', content: 'G' },
+      { index: 0, voice: 'l1', content: 'The' }
+    ];
+
+    const actualEvent = createEventFromVerse(nextVoices, ['c1', 'c2', 'l1', 'l2']);
+
+    expect(actualEvent).toEqual(expectedEvent);
+  });
+
+  test('should transform a verse into a list of events', () => {
+    const verse = [
+      new Map([[
+        'c1', [
+          { index: 19, content: new Chord('A', 'm') },
+        ]], [
+        'l1', [
+          { index: 0, content: 'All' },
+          { index: 4, content: 'the' },
+          { index: 8, content: 'leaves' },
+          { index: 15, content: 'are' },
+          { index: 19, content: 'brown' },
+        ]]
+      ]),
+      new Map([[
+        'c1', [
+          { index: 0, content: new Chord('G') },
+          { index: 3, content: new Chord('F') },
+          { index: 14, content: new Chord('G') },
+          { index: 21, content: new Chord('E', 'sus2') },
+          { index: 27, content: new Chord('E') },
+        ]], [
+        'l1', [
+          { index: 6, content: 'and' },
+          { index: 10, content: 'the' },
+          { index: 14, content: 'sky' },
+          { index: 18, content: 'is' },
+          { index: 21, content: 'gray.' },
+        ]]
+      ])
+    ];
+
+    const expectedEvents = [
+      [
+        [{ index: 0, voice: 'l1', content: 'All' }],
+        [{ index: 4, voice: 'l1', content: 'the' }],
+        [{ index: 8, voice: 'l1', content: 'leaves' }],
+        [{ index: 15, voice: 'l1', content: 'are' }],
+        [
+          { index: 19, voice: 'c1', content: new Chord('A', 'm') },
+          { index: 19, voice: 'l1', content: 'brown' },
+        ]
+      ],
+      [
+        [{ index: 0, voice: 'c1', content: new Chord('G') }],
+        [{ index: 3, voice: 'c1', content: new Chord('F') }],
+        [{ index: 6, voice: 'l1', content: 'and' }],
+        [{ index: 10, voice: 'l1', content: 'the' }],
+        [
+          { index: 14, voice: 'c1', content: new Chord('G') },
+          { index: 14, voice: 'l1', content: 'sky' },
+        ],
+        [{ index: 18, voice: 'l1', content: 'is' }],
+        [
+          { index: 21, voice: 'c1', content: new Chord('E', 'sus2') },
+          { index: 21, voice: 'l1', content: 'gray.' },
+        ],
+        [{ index: 27, voice: 'c1', content: new Chord('E') }]
+      ]
+    ];
+
+    const actualEventList = convertVersesToEvents(verse);
+    expect(actualEventList).toEqual(expectedEvents);
+  });
+
+  test('should split a previous event if there is overlap', () => {
+    const verses = [
+      new Map([[
+        'c1', [
+          { index: 0, content: new Chord('A') },
+          { index: 11, content: new Chord('C') },
+          { index: 20, content: new Chord('D') },
+          { index: 31, content: new Chord('E') },
+        ]], [
+        'l1', [
+          { index: 0, content: 'longest' },
+          { index: 8, content: 'is' },
+          { index: 11, content: 'supercalifragilisticexpialidocious' }
+        ]]
+      ])
+    ];
+
+    const expectedEventList = [
+      [
+        [
+          { index: 0, voice: 'c1', content: new Chord('A') },
+          { index: 0, voice: 'l1', content: 'longest' },
+        ],
+        [
+          { index: 8, voice: 'l1', content: 'is' },
+        ],
+        [
+          { index: 11, voice: 'c1', content: new Chord('C') },
+          { index: 11, voice: 'l1', content: 'supercali' }
+        ],
+        [
+          { index: 20, voice: 'c1', content: new Chord('D') },
+          { index: 20, voice: 'l1', content: '-fragilistic' }
+        ],
+        [
+          { index: 32, voice: 'c1', content: new Chord('E') },
+          { index: 32, voice: 'l1', content: '-expialidocious' }
+        ],
+      ]
+    ];
+
+    const actualEventList = convertVersesToEvents(verses);
+
+    expect(actualEventList).toEqual(expectedEventList);
+  });
+});


### PR DESCRIPTION
#3 

Initial implementation for converting verses to events. An "event" is one of each voice that falls within a range. Each verse is parsed into its own event list, so the output of this conversion will be a list of event lists (3 levels of lists). Additionally, if a voice would be split across several events (a really long word with multiple chords for example), this will split the long voice across all events it applies to, adding `-` between the broken word, changing `supercalifragilisticexpialidocious` to `supercali-fragilistic-expiali-docious`.

For example, 

```
c1:                    Am     G  F          G      Esus4  E
v1: All the leaves are brown        and the sky is gray
````

the first event would be

```
[ { index: 0, voice: 'v1', content: 'All' } ]
```

and another event with multiple voices would be 

```
[
  { index: 19, voice: 'c1', content: new Chord('A', 'm') },
  { index: 19, voice: 'l1', content: 'brown' },
]
```

Probably going to add more tests as I write out the renderer, but this does what I want for now. 