### PR TITLE
Render as events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const abc = require('./renderers/abc_renderer.js');
-const chords = require('./renderers/chords_renderer.js');
+const chords = require('./renderers/chords_renderer_from_events.js');
 
 function MarkdownMusic(md, musicOpts) {
   md.highlightRegistry = {};
@@ -10,7 +10,7 @@ function MarkdownMusic(md, musicOpts) {
     highlight: function(str, lang) {
       if (md.highlightRegistry.hasOwnProperty(lang)) {
         try {
-          return md.highlightRegistry[lang](str, md.musicOpts);
+          return `<pre style="display: none;"></pre>${md.highlightRegistry[lang](str, md.musicOpts)}`;
         } catch (error) {
           return `<pre>${str}</pre><div class="error">${error}</div>`;
         }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function MarkdownMusic(md, musicOpts) {
     highlight: function(str, lang) {
       if (md.highlightRegistry.hasOwnProperty(lang)) {
         try {
+          // If we don't start our HTML with <pre, markdown-it will automatically wrap out output in <pre></pre>.
           return `<pre style="display: none;"></pre>${md.highlightRegistry[lang](str, md.musicOpts)}`;
         } catch (error) {
           return `<pre>${str}</pre><div class="error">${error}</div>`;

--- a/parsers/events.spec.js
+++ b/parsers/events.spec.js
@@ -183,7 +183,7 @@ describe('Event', () => {
           { index: 8, offset: 1, voice: 'l1', content: 'is' },
         ],
         [
-          { index: 11, offset: 1, offset: 1, voice: 'c1', content: new Chord('C') },
+          { index: 11, offset: 1, voice: 'c1', content: new Chord('C') },
           { index: 11, offset: 1, voice: 'l1', content: 'supercali' }
         ],
         [

--- a/parsers/events.spec.js
+++ b/parsers/events.spec.js
@@ -5,15 +5,15 @@ const Chord = require('./chord.js');
 const eventsjs = rewire('./events.js');
 
 const convertVerseToEvents = eventsjs.__get__('convertVerseToEvents');
-const EventList = eventsjs.__get__('EventList');
+const Line = eventsjs.__get__('Line');
 
 describe('Event', () => {
   test('should add voices', () => {
-    const expectedEvent = [
-      { index: 4, voice: 'c1', content: 'G' },
-      { index: 4, voice: 'c2', content: 'C' },
-      { index: 4, voice: 'l1', content: 'longest' },
-      { index: 4, voice: 'a1', content: 'crash!' },
+    const expectedLine = [
+      { index: 4, offset: 1, voice: 'c1', content: 'G' },
+      { index: 4, offset: 1, voice: 'c2', content: 'C' },
+      { index: 4, offset: 1, voice: 'l1', content: 'longest' },
+      { index: 4, offset: 1, voice: 'a1', content: 'crash!' },
     ];
 
     const nextVoices = new Map([[
@@ -31,14 +31,14 @@ describe('Event', () => {
       ]]
     ]);
 
-    const eventList = new EventList();
-    const actualEvent = eventList.createEventListFromPhrase(nextVoices, ['c1', 'c2', 'l1', 'a1']);
+    const line = new Line();
+    const actualLine = line.createLineFromPhrase(nextVoices, ['c1', 'c2', 'l1', 'a1']);
 
-    expect(actualEvent).toEqual(expectedEvent);
+    expect(actualLine).toEqual(expectedLine);
   });
 
   test('should only add voices that are in index range', () => {
-    const nextVoices = new Map([[
+    const phrase = new Map([[
       'c1', [
         { index: 4, content: 'G' },
       ]], [
@@ -53,19 +53,19 @@ describe('Event', () => {
       ]]
     ]);
 
-    const expectedEvent = [
-      { index: 0, voice: 'l1', content: 'The' },
-      { index: 0, voice: 'l2', content: 'Test' }
+    const expectedLine = [
+      { index: 0, offset: 1, voice: 'l1', content: 'The' },
+      { index: 0, offset: 1, voice: 'l2', content: 'Test' }
     ];
 
-    const eventList = new EventList();
-    const actualEvent = eventList.createEventListFromPhrase(nextVoices, ['c1', 'c2', 'l1', 'l2']);
+    const line = new Line();
+    const actualLine = line.createLineFromPhrase(phrase, ['c1', 'c2', 'l1', 'l2']);
 
-    expect(actualEvent).toEqual(expectedEvent);
+    expect(actualLine).toEqual(expectedLine);
   });
 
   test('should add next index first', () => {
-    const nextVoices = new Map([[
+    const phrase = new Map([[
       'c1', [
         { index: 0, content: 'G' },
       ]], [
@@ -80,15 +80,15 @@ describe('Event', () => {
       ]]
     ]);
 
-    const expectedEvent = [
-      { index: 0, voice: 'c1', content: 'G' },
-      { index: 0, voice: 'l1', content: 'The' }
+    const expectedLine = [
+      { index: 0, offset: 1, voice: 'c1', content: 'G' },
+      { index: 0, offset: 1, voice: 'l1', content: 'The' }
     ];
 
-    const eventList = new EventList();
-    const actualEvent = eventList.createEventListFromPhrase(nextVoices, ['c1', 'c2', 'l1', 'l2']);
+    const line = new Line();
+    const actualLine = line.createLineFromPhrase(phrase, ['c1', 'c2', 'l1', 'l2']);
 
-    expect(actualEvent).toEqual(expectedEvent);
+    expect(actualLine).toEqual(expectedLine);
   });
 
   test('should transform a verse into a list of events', () => {
@@ -123,37 +123,37 @@ describe('Event', () => {
       ])
     ];
 
-    const expectedEvents = [
+    const expectedLines = [
       [
-        [{ index: 0, voice: 'l1', content: 'All' }],
-        [{ index: 4, voice: 'l1', content: 'the' }],
-        [{ index: 8, voice: 'l1', content: 'leaves' }],
-        [{ index: 15, voice: 'l1', content: 'are' }],
+        [{ index: 0, offset: 1, voice: 'l1', content: 'All' }],
+        [{ index: 4, offset: 1, voice: 'l1', content: 'the' }],
+        [{ index: 8, offset: 1, voice: 'l1', content: 'leaves' }],
+        [{ index: 15, offset: 1, voice: 'l1', content: 'are' }],
         [
-          { index: 19, voice: 'c1', content: new Chord('A', 'm') },
-          { index: 19, voice: 'l1', content: 'brown' },
+          { index: 19, offset: 1, voice: 'c1', content: new Chord('A', 'm') },
+          { index: 19, offset: 1, voice: 'l1', content: 'brown' },
         ]
       ],
       [
-        [{ index: 0, voice: 'c1', content: new Chord('G') }],
-        [{ index: 3, voice: 'c1', content: new Chord('F') }],
-        [{ index: 6, voice: 'l1', content: 'and' }],
-        [{ index: 10, voice: 'l1', content: 'the' }],
+        [{ index: 0, offset: 1, voice: 'c1', content: new Chord('G') }],
+        [{ index: 3, offset: 1, voice: 'c1', content: new Chord('F') }],
+        [{ index: 6, offset: 1, voice: 'l1', content: 'and' }],
+        [{ index: 10, offset: 1, voice: 'l1', content: 'the' }],
         [
-          { index: 14, voice: 'c1', content: new Chord('G') },
-          { index: 14, voice: 'l1', content: 'sky' },
+          { index: 14, offset: 1, voice: 'c1', content: new Chord('G') },
+          { index: 14, offset: 1, voice: 'l1', content: 'sky' },
         ],
-        [{ index: 18, voice: 'l1', content: 'is' }],
+        [{ index: 18, offset: 1, voice: 'l1', content: 'is' }],
         [
-          { index: 21, voice: 'c1', content: new Chord('E', 'sus2') },
-          { index: 21, voice: 'l1', content: 'gray.' },
+          { index: 21, offset: 1, voice: 'c1', content: new Chord('E', 'sus2') },
+          { index: 21, offset: 1, voice: 'l1', content: 'gray.' },
         ],
-        [{ index: 27, voice: 'c1', content: new Chord('E') }]
+        [{ index: 27, offset: 1, voice: 'c1', content: new Chord('E') }]
       ]
     ];
 
-    const actualEventList = convertVerseToEvents(verse);
-    expect(actualEventList).toEqual(expectedEvents);
+    const actualLines = convertVerseToEvents(verse);
+    expect(actualLines).toEqual(expectedLines);
   });
 
   test('should split a previous event if there is overlap', () => {
@@ -173,33 +173,33 @@ describe('Event', () => {
       ])
     ];
 
-    const expectedEventList = [
+    const expectedLines = [
       [
         [
-          { index: 0, voice: 'c1', content: new Chord('A') },
-          { index: 0, voice: 'l1', content: 'longest' },
+          { index: 0, offset: 1, voice: 'c1', content: new Chord('A') },
+          { index: 0, offset: 1, voice: 'l1', content: 'longest' },
         ],
         [
-          { index: 8, voice: 'l1', content: 'is' },
+          { index: 8, offset: 1, voice: 'l1', content: 'is' },
         ],
         [
-          { index: 11, voice: 'c1', content: new Chord('C') },
-          { index: 11, voice: 'l1', content: 'supercali' }
+          { index: 11, offset: 1, offset: 1, voice: 'c1', content: new Chord('C') },
+          { index: 11, offset: 1, voice: 'l1', content: 'supercali' }
         ],
         [
-          { index: 20, voice: 'c1', content: new Chord('D') },
-          { index: 20, voice: 'l1', content: '-fragilistic' }
+          { index: 20, offset: 1, voice: 'c1', content: new Chord('D') },
+          { index: 20, offset: 0, voice: 'l1', content: '-fragilistic' }
         ],
         [
-          { index: 32, voice: 'c1', content: new Chord('E') },
-          { index: 32, voice: 'l1', content: '-expialidocious' }
+          { index: 32, offset: 1, voice: 'c1', content: new Chord('E') },
+          { index: 32, offset: 0, voice: 'l1', content: '-expialidocious' }
         ],
       ]
     ];
 
-    const actualEventList = convertVerseToEvents(verse);
+    const actualLines = convertVerseToEvents(verse);
 
-    expect(actualEventList).toEqual(expectedEventList);
+    expect(actualLines).toEqual(expectedLines);
   });
 
   test('should split all previous events when long events exist in different phrases', () => {
@@ -224,19 +224,52 @@ describe('Event', () => {
       ]),
     ];
 
-    const expectedEventList = [
+    const expectedLines = [
       [
-        [{ index: 0, voice: 'c1', content: new Chord('Am') }, { index: 0, voice: 'l1', content: 'Wonder' }],
-        [{ index: 6, voice: 'c1', content: new Chord('C') }, { index: 6, voice: 'l1', content: '-ful' }]
+        [
+          { index: 0, offset: 1, voice: 'c1', content: new Chord('Am') },
+          { index: 0, offset: 1, voice: 'l1', content: 'Wonder' }
+        ],
+        [
+          { index: 6, offset: 1, voice: 'c1', content: new Chord('C') },
+          { index: 6, offset: 0, voice: 'l1', content: '-ful' }
+        ]
       ],
       [
-        [{ index: 0, voice: 'c1', content: new Chord('Am') }, { index: 0, voice: 'l1', content: 'Test' }],
-        [{ index: 4, voice: 'c1', content: new Chord('C') }, { index: 4, voice: 'l1', content: '-ing' }]
+        [
+          { index: 0, offset: 1, voice: 'c1', content: new Chord('Am') },
+          { index: 0, offset: 1, voice: 'l1', content: 'Test' }
+        ],
+        [
+          { index: 4, offset: 1, voice: 'c1', content: new Chord('C') },
+          { index: 4, offset: 0, voice: 'l1', content: '-ing' }
+        ]
       ]
     ];
 
-    const actualEventList = convertVerseToEvents(verse);
+    const actualLines = convertVerseToEvents(verse);
 
-    expect(actualEventList).toEqual(expectedEventList);
+    expect(actualLines).toEqual(expectedLines);
+  });
+
+  test('should include offset when a voice is not at the start index of an event', () => {
+    const phrase = new Map([[
+      'c1', [
+        { index: 2, content: new Chord('C') }
+      ]], [
+      'l1', [
+        { index: 0, content: 'Testing' }
+      ]]
+    ]);
+
+    const line = new Line();
+    const actualLine = line.createLineFromPhrase(phrase, ['c1', 'l1']);
+
+    const expectedLine = [
+      { index: 2, voice: 'c1', content: new Chord('C'), offset: 3 },
+      { index: 0, voice: 'l1', content: 'Testing', offset: 1 }
+    ];
+
+    expect(actualLine).toEqual(expectedLine);
   });
 });

--- a/renderers/chord_hover.js
+++ b/renderers/chord_hover.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const chordDiagram = require('./chord_diagram.js');
+const { guitarChordLibrary } = require('./chord_library.js');
+
+function addChordToDiv(voiceDiv, chord) {
+  voiceDiv.className += ' chord';
+
+  if (guitarChordLibrary.has(chord.toString())) {
+    const chordDiagramDiv = document.createElement('div');
+    chordDiagramDiv.className = 'diagram';
+
+    const shorthands = guitarChordLibrary.get(chord.toString());
+    const svgs = shorthands.map((shorthand) => chordDiagram.renderChordDiagram(shorthand));
+
+    // TODO: Provide a way to scroll through several chord diagrams.
+    chordDiagramDiv.innerHTML = svgs[0];
+    voiceDiv.appendChild(chordDiagramDiv);
+  }
+}
+
+module.exports = {
+  addChordToDiv
+};

--- a/renderers/chord_hover.js
+++ b/renderers/chord_hover.js
@@ -16,6 +16,8 @@ function addChordToDiv(voiceDiv, chord) {
     // TODO: Provide a way to scroll through several chord diagrams.
     chordDiagramDiv.innerHTML = svgs[0];
     voiceDiv.appendChild(chordDiagramDiv);
+  } else {
+    voiceDiv.className += ' highlight';
   }
 }
 

--- a/renderers/chord_hover.spec.js
+++ b/renderers/chord_hover.spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const rewire = require('rewire');
+
+const chordHoverJs = rewire('./chord_hover.js');
+chordHoverJs.__set__('document', document);
+chordHoverJs.__get__('chordDiagram').renderChordDiagram = jest.fn(() => 'svg_here');
+
+const addChordToDiv = chordHoverJs.__get__('addChordToDiv');
+
+const svgDiagramDiv = '<div class="diagram">svg_here</div>';
+
+describe('Chord hover', () => {
+  test('should add diagram and chord class', () => {
+    const voiceDiv = document.createElement('div');
+
+    addChordToDiv(voiceDiv, 'C');
+
+    const expectedVoiceDiv = `<div class=" chord">${svgDiagramDiv}</div>`;
+
+    expect(voiceDiv.outerHTML).toEqual(expectedVoiceDiv);
+  });
+
+  test('should highlight chord if diagram does not exist', () => {
+    const voiceDiv = document.createElement('div');
+
+    addChordToDiv(voiceDiv, '!!!!');
+
+    const expectedVoiceDiv = '<div class=" chord highlight"></div>';
+
+    expect(voiceDiv.outerHTML).toEqual(expectedVoiceDiv);
+  });
+});

--- a/renderers/chords_renderer.js
+++ b/renderers/chords_renderer.js
@@ -1,28 +1,9 @@
 'use strict';
 
 const parseVerse = require('../parsers/verse.js')['parseVerse'];
-const chordDiagram = require('./chord_diagram.js');
-const { guitarChordLibrary } = require('./chord_library.js');
-const randomColor = require('randomcolor');
+const chordHover = require('./chord_hover.js');
 
-class VoiceColors {
-  constructor() {
-    this.colors = ['blue', 'black', 'red', 'green', 'purple', 'teal'];
-    this.voiceColorMap = {};
-  }
-
-  getUnusedColor() {
-    return this.colors.length > 0 ? this.colors.shift() : randomColor({ seed: 42 });
-  }
-
-  getVoiceColor(voice) {
-    if (!(voice in this.voiceColorMap)) {
-      this.voiceColorMap[voice] = this.getUnusedColor();
-    }
-
-    return this.voiceColorMap[voice];
-  }
-}
+const VoiceColors = require('./voice_colors.js');
 
 function createHtmlChordChart(verse, opts) {
   const chordChartHtml = document.createElement('div');
@@ -92,19 +73,7 @@ function appendVoiceContentDiv(parentVoice, text, whitespace, className) {
   textDiv.className = className;
 
   if (className.startsWith('c')) {
-    textDiv.className += ' chord';
-
-    if (guitarChordLibrary.has(text.toString())) {
-      const chordDiagramDiv = document.createElement('div');
-      chordDiagramDiv.className = 'diagram';
-
-      const shorthands = guitarChordLibrary.get(text.toString());
-      const svgs = shorthands.map(
-        (shorthand) => chordDiagram.renderChordDiagram(shorthand));
-      // TODO: Provide a way to scroll through several chord diagrams.
-      chordDiagramDiv.innerHTML = svgs[0];
-      textDiv.appendChild(chordDiagramDiv);
-    }
+    chordHover.addChordToDiv(textDiv, text);
   }
 
   textDiv.innerHTML += text.toString();

--- a/renderers/chords_renderer.spec.js
+++ b/renderers/chords_renderer.spec.js
@@ -1,29 +1,31 @@
 'use strict';
 
-// jest.mock('./chord_diagram.js');
-
 const Chord = require('../parsers/chord.js');
 
 const rewire = require('rewire');
 const chordsrendererjs = rewire('./chords_renderer.js');
 chordsrendererjs.__set__('document', document);
-chordsrendererjs.__get__('chordDiagram').renderChordDiagram = jest.fn(() => 'svg_here');
+
+const mockAddChordToDivFn = jest.fn(() => 'svg_here');
+chordsrendererjs.__get__('chordHover').addChordToDiv = mockAddChordToDivFn;
 
 const createHtmlChordChart = chordsrendererjs.__get__('createHtmlChordChart');
 const createListOfWrappedVoices = chordsrendererjs.__get__('createListOfWrappedVoices');
 const appendVoiceContentDiv = chordsrendererjs.__get__('appendVoiceContentDiv');
 const VoiceColors = chordsrendererjs.__get__('VoiceColors');
 
-const svgDiagramDiv = '<div class="diagram">svg_here</div>';
-
 describe('JSON to HTML converter', () => {
   const defaultColors = ['blue', 'black', 'red', 'green', 'purple', 'teal'];
+
+  beforeEach(() => {
+    mockAddChordToDivFn.mockClear();
+  });
 
   test('should wrap voice in div', () => {
     const parentDiv = document.createElement('div');
     appendVoiceContentDiv(parentDiv, 'The', 1, 'c1');
 
-    const expectedDiv = `<div><div> </div><div class="c1 chord">The</div></div>`;
+    const expectedDiv = `<div><div> </div><div class="c1">The</div></div>`;
 
     expect(parentDiv.outerHTML).toEqual(expectedDiv);
   });
@@ -32,9 +34,10 @@ describe('JSON to HTML converter', () => {
     const parentDiv = document.createElement('div');
     appendVoiceContentDiv(parentDiv, new Chord('C'), 0, 'c1');
 
-    const expectedDiv = `<div><div class="c1 chord">${svgDiagramDiv}C</div></div>`;
+    const expectedDiv = `<div><div class="c1">C</div></div>`;
 
     expect(parentDiv.outerHTML).toEqual(expectedDiv);
+    expect(mockAddChordToDivFn).toHaveBeenCalledTimes(1);
   });
 
   test('should append several chords to same parent div', () => {
@@ -43,11 +46,12 @@ describe('JSON to HTML converter', () => {
     appendVoiceContentDiv(parentDiv, new Chord('G'), 5, 'c1');
 
     const expectedDiv = `<div>` +
-      `<div class="c1 chord">${svgDiagramDiv}C</div>` +
-      `<div>     </div><div class="c1 chord">${svgDiagramDiv}G</div>` +
+      `<div class="c1">C</div>` +
+      `<div>     </div><div class="c1">G</div>` +
     `</div>`;
 
     expect(parentDiv.outerHTML).toEqual(expectedDiv);
+    expect(mockAddChordToDivFn).toHaveBeenCalledTimes(2);
   });
 
   describe('wrapped voices', () => {
@@ -91,21 +95,21 @@ describe('JSON to HTML converter', () => {
 
       const expectedChordChartHtmlList = [
         `<div class="voice" style="color: ${defaultColors[0]};">` +
-          `<div>    </div><div class="c1 chord">${svgDiagramDiv}G</div>` +
-          `<div>       </div><div class="c1 chord">${svgDiagramDiv}F</div>` +
-          `<div>       </div><div class="c1 chord">${svgDiagramDiv}Am</div>` +
-          `<div>       </div><div class="c1 chord">${svgDiagramDiv}G</div>` +
-          `<div>          </div><div class="c1 chord">${svgDiagramDiv}F</div>` +
-          `<div>      </div><div class="c1 chord">${svgDiagramDiv}C</div>` +
+          `<div>    </div><div class="c1">G</div>` +
+          `<div>       </div><div class="c1">F</div>` +
+          `<div>       </div><div class="c1">Am</div>` +
+          `<div>       </div><div class="c1">G</div>` +
+          `<div>          </div><div class="c1">F</div>` +
+          `<div>      </div><div class="c1">C</div>` +
         '</div>',
 
         `<div class="voice" style="color: ${defaultColors[1]};">` +
-          `<div>    </div><div class="c2 chord">${svgDiagramDiv}C</div>` +
-          `<div>       </div><div class="c2 chord">${svgDiagramDiv}D</div>` +
-          `<div>       </div><div class="c2 chord">${svgDiagramDiv}Cm</div>` +
-          `<div>       </div><div class="c2 chord">${svgDiagramDiv}F</div>` +
-          `<div>          </div><div class="c2 chord">${svgDiagramDiv}G</div>` +
-          `<div>      </div><div class="c2 chord">${svgDiagramDiv}B</div>` +
+          `<div>    </div><div class="c2">C</div>` +
+          `<div>       </div><div class="c2">D</div>` +
+          `<div>       </div><div class="c2">Cm</div>` +
+          `<div>       </div><div class="c2">F</div>` +
+          `<div>          </div><div class="c2">G</div>` +
+          `<div>      </div><div class="c2">B</div>` +
         '</div>',
 
         `<div class="voice" style="color: ${defaultColors[2]};">` +
@@ -129,6 +133,7 @@ describe('JSON to HTML converter', () => {
         .map((html) => html.outerHTML);
 
       expect(actualHtmlList).toEqual(expectedChordChartHtmlList);
+      expect(mockAddChordToDivFn).toHaveBeenCalledTimes(12);
     });
 
     test('should transpose a chord if transpose is provided', () => {
@@ -138,7 +143,7 @@ describe('JSON to HTML converter', () => {
 
       const expectedPhraseHtml = [
         `<div class="voice" style="color: ${defaultColors[0]};">` +
-          `<div class="c1 chord">${svgDiagramDiv}C#</div>` +
+          `<div class="c1">C#</div>` +
         '</div>'
       ];
 
@@ -146,6 +151,7 @@ describe('JSON to HTML converter', () => {
         .map((html) => html.outerHTML);
 
       expect(wrappedVoices).toEqual(expectedPhraseHtml);
+      expect(mockAddChordToDivFn).toHaveBeenCalledTimes(1);
     });
 
     test('should not try to transpose anything that is not a chord', () => {
@@ -205,8 +211,8 @@ describe('JSON to HTML converter', () => {
       '<div class="chart">' +
         '<div class="verse">' +
           `<div class="voice" style="color: ${defaultColors[0]};">` +
-            `<div class="c1 chord">${svgDiagramDiv}C</div>` +
-            `<div>   </div><div class="c1 chord">${svgDiagramDiv}G</div>` +
+            `<div class="c1">C</div>` +
+            `<div>   </div><div class="c1">G</div>` +
           '</div>' +
           `<div class="voice" style="color: ${defaultColors[1]};">` +
             '<div class="l1">Test</div>' +
@@ -214,7 +220,7 @@ describe('JSON to HTML converter', () => {
         '</div>' +
         '<div class="verse">' +
           `<div class="voice" style="color: ${defaultColors[0]};">` +
-            `<div class="c1 chord">${svgDiagramDiv}A</div>` +
+            `<div class="c1">A</div>` +
           '</div>' +
           `<div class="voice" style="color: ${defaultColors[1]};">` +
             '<div class="l1">Song</div>' +
@@ -223,6 +229,7 @@ describe('JSON to HTML converter', () => {
       '</div>';
 
     expect(createHtmlChordChart(verse).outerHTML).toEqual(expectedDiv);
+    expect(mockAddChordToDivFn).toHaveBeenCalledTimes(3);
   });
 
   test('should get default colors for first voices', () => {

--- a/renderers/chords_renderer_from_events.js
+++ b/renderers/chords_renderer_from_events.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const parseVerse = require('../parsers/verse.js')['parseVerse'];
+const chordHover = require('./chord_hover.js');
+const { convertVerseToEvents } = require('../parsers/events.js');
+
+const VoiceColors = require('./voice_colors.js');
+
+class ChordsEventRenderer {
+  constructor(voiceOrder, colorOrder, opts) {
+    this.voiceOrder = voiceOrder;
+    this.voiceColors = new VoiceColors(colorOrder);
+    this.transposeAmount = opts ? opts.transpose : undefined;
+  }
+
+  createEventHTMLChordChart(lines) {
+    // create chart div
+    const chartDiv = document.createElement('div');
+    chartDiv.className = 'chart';
+
+    // create events div for each line list
+    lines.forEach((line) => {
+      // create line div for each event
+      chartDiv.appendChild(this.createLineDiv(line));
+    });
+
+    return chartDiv;
+  }
+
+  createLineDiv(line) {
+    const lineDiv = document.createElement('div');
+    lineDiv.className = 'line';
+
+    // add all voices from event to line div
+    line.forEach((event) => {
+      lineDiv.appendChild(this.createEventDiv(event));
+    });
+
+    return lineDiv;
+  }
+
+  createEventDiv(event) {
+    const eventDiv = document.createElement('div');
+    eventDiv.className = 'event';
+
+    let currentVoiceIndex = 0;
+
+    event.forEach((voice) => {
+      while (voice.voice !== this.voiceOrder[currentVoiceIndex]) {
+        const emptyDiv = document.createElement('div');
+        emptyDiv.innerHTML = ' ';
+
+        eventDiv.appendChild(emptyDiv);
+        currentVoiceIndex++;
+      }
+
+      currentVoiceIndex++;
+
+      eventDiv.appendChild(this.createVoiceDiv(voice));
+    });
+
+    return eventDiv;
+  }
+
+  createVoiceDiv(voice) {
+    const voiceStyleDiv = document.createElement('div');
+    voiceStyleDiv.style.color = this.voiceColors.getVoiceColor(voice.voice);
+
+    const voiceDiv = document.createElement('div');
+    voiceDiv.className = voice.voice;
+
+    if (voice.voice.startsWith('c')) {
+      if (this.transposeAmount && typeof voice.content.transpose === 'function') {
+        voice.content = voice.content.transpose(this.transposeAmount);
+      }
+
+      chordHover.addChordToDiv(voiceDiv, voice.content);
+    }
+    voiceDiv.innerHTML += `${' '.repeat(voice.offset)}${voice.content.toString()}`;
+
+    voiceStyleDiv.appendChild(voiceDiv);
+
+    return voiceStyleDiv;
+  }
+}
+
+function render(str, opts) {
+  const verse = parseVerse(str);
+  // Get voice order from first phrase
+  const voiceOrder = Array.from(verse[0].keys());
+
+  const chordsRenderer = new ChordsEventRenderer(voiceOrder, colorOrder, opts);
+  const lines = convertVerseToEvents(verse);
+
+  return chordsRenderer.createEventHTMLChordChart(lines).outerHTML;
+}
+
+module.exports = {
+  'callback': render,
+  'lang': 'chords'
+};

--- a/renderers/chords_renderer_from_events.js
+++ b/renderers/chords_renderer_from_events.js
@@ -89,6 +89,8 @@ function render(str, opts) {
   // Get voice order from first phrase
   const voiceOrder = Array.from(verse[0].keys());
 
+  const colorOrder = ['black', 'blue', 'red', 'green', 'purple', 'teal'];
+
   const chordsRenderer = new ChordsEventRenderer(voiceOrder, colorOrder, opts);
   const lines = convertVerseToEvents(verse);
 

--- a/renderers/chords_renderer_from_events.spec.js
+++ b/renderers/chords_renderer_from_events.spec.js
@@ -78,7 +78,7 @@ describe('Chords Renderer from Events', () => {
       `</div>` +
     '</div>';
 
-    const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors,);
+    const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors);
     const actualEventDiv = chordsRenderer.createEventDiv(line);
 
     expect(actualEventDiv.outerHTML).toEqual(expectedEventDiv);

--- a/renderers/chords_renderer_from_events.spec.js
+++ b/renderers/chords_renderer_from_events.spec.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const rewire = require('rewire');
+
+const chordsRendererFromEventsJs = rewire('./chords_renderer_from_events.js');
+chordsRendererFromEventsJs.__set__('document', document);
+
+const mockAddChordToDivFn = jest.fn(() => 'svg_here');
+chordsRendererFromEventsJs.__get__('chordHover').addChordToDiv = mockAddChordToDivFn;
+
+const ChordsEventRenderer = chordsRendererFromEventsJs.__get__('ChordsEventRenderer');
+
+describe('Chords Renderer from Events', () => {
+  const defaultColors = ['black', 'blue', 'red', 'green', 'purple', 'teal'];
+  let voiceColors;
+
+  beforeEach(() => {
+    mockAddChordToDivFn.mockClear();
+    voiceColors = ['black', 'blue', 'red', 'green', 'purple', 'teal'];
+  });
+
+  test('should create a voice div', () => {
+    const expectedVoiceDiv =
+      `<div style="color: ${defaultColors[0]};">` +
+        `<div class="c1"> C</div>` +
+      `</div>`;
+
+    const voice = { index: 0, offset: 1, voice: 'c1', content: 'C' };
+
+    const chordsRenderer = new ChordsEventRenderer(['c1'], voiceColors);
+    const actualVoiceDiv = chordsRenderer.createVoiceDiv(voice);
+
+    expect(actualVoiceDiv.outerHTML).toEqual(expectedVoiceDiv);
+    expect(mockAddChordToDivFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('should create a line div', () => {
+    const expectedLineDiv = '<div class="line">' +
+      '<div class="event">' +
+        `<div style="color: ${defaultColors[0]};">` +
+          `<div class="l1"> Line</div>` +
+        `</div>` +
+      '</div>' +
+      '<div class="event">' +
+        `<div style="color: ${defaultColors[0]};">` +
+          `<div class="l1"> Test</div>` +
+        `</div>` +
+      '</div>' +
+    '</div>';
+
+    const line = [
+      [
+        { index: 0, offset: 1, voice: 'l1', content: 'Line' },
+      ],
+      [
+        { index: 0, offset: 1, voice: 'l1', content: 'Test' },
+      ]
+    ];
+
+    const chordsRenderer = new ChordsEventRenderer(['l1'], voiceColors);
+    const actualLineDiv = chordsRenderer.createLineDiv(line);
+
+    expect(actualLineDiv.outerHTML).toEqual(expectedLineDiv);
+  });
+
+  test('should add diagram to chord div', () => {
+    const line = [
+      { index: 0, offset: 1, voice: 'c1', content: 'C' },
+      { index: 0, offset: 1, voice: 'l1', content: 'Wonderful!' },
+    ];
+
+    const expectedEventDiv = '<div class="event">' +
+      `<div style="color: ${defaultColors[0]};">` +
+        `<div class="c1"> C</div>` +
+      `</div>` +
+      `<div style="color: ${defaultColors[1]};">` +
+        `<div class="l1"> Wonderful!</div>` +
+      `</div>` +
+    '</div>';
+
+    const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors,);
+    const actualEventDiv = chordsRenderer.createEventDiv(line);
+
+    expect(actualEventDiv.outerHTML).toEqual(expectedEventDiv);
+    expect(mockAddChordToDivFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('should create a chart that contains two phrases that each contain two lines of events.', () => {
+    const lines = [[
+      [
+        { index: 0, offset: 1, voice: 'c1', content: 'C' },
+        { index: 0, offset: 1, voice: 'l1', content: 'Wonderful' },
+      ],
+      [
+        { index: 0, offset: 1, voice: 'c1', content: 'G' },
+        { index: 0, offset: 1, voice: 'l1', content: 'Testing!' },
+      ]
+    ],
+    [
+      [
+        { index: 0, offset: 1, voice: 'c1', content: 'A' },
+        { index: 0, offset: 1, voice: 'l1', content: 'Things' },
+      ],
+      [
+        { index: 10, offset: 1, voice: 'l1', content: 'IsGreat!' },
+      ]
+    ]];
+
+    const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors);
+    const actualChartDiv = chordsRenderer.createEventHTMLChordChart(lines);
+
+    const expectedEventDiv = '<div class="chart">' +
+      '<div class="line">' +
+        '<div class="event">' +
+          `<div style="color: ${defaultColors[0]};">` +
+            `<div class="c1"> C</div>` +
+          `</div>` +
+          `<div style="color: ${defaultColors[1]};">` +
+            `<div class="l1"> Wonderful</div>` +
+          `</div>` +
+        '</div>' +
+        '<div class="event">' +
+          `<div style="color: ${defaultColors[0]};">` +
+            `<div class="c1"> G</div>` +
+          `</div>` +
+          `<div style="color: ${defaultColors[1]};">` +
+            `<div class="l1"> Testing!</div>` +
+          `</div>` +
+        '</div>' +
+      '</div>' +
+      '<div class="line">' +
+        '<div class="event">' +
+          `<div style="color: ${defaultColors[0]};">` +
+            `<div class="c1"> A</div>` +
+          `</div>` +
+          `<div style="color: ${defaultColors[1]};">` +
+            `<div class="l1"> Things</div>` +
+          `</div>` +
+        '</div>' +
+        '<div class="event">' +
+          `<div> </div>` +
+          `<div style="color: ${defaultColors[1]};">` +
+            `<div class="l1"> IsGreat!</div>` +
+          `</div>` +
+        '</div>' +
+      '</div>' +
+    '</div>';
+
+    expect(actualChartDiv.outerHTML).toEqual(expectedEventDiv);
+    expect(mockAddChordToDivFn).toHaveBeenCalledTimes(3);
+  });
+
+  test('should not add a space to a split event', () => {
+    // This isn't actually a incredibly useful test any more since it all works off the offset.
+    // Keeping it though since it's good to have a test help document functionality.
+    const expectedLineDiv ='<div class="line">' +
+      '<div class="event">' +
+        `<div style="color: ${defaultColors[0]};">` +
+          `<div class="l1"> Wonder</div>` +
+        `</div>` +
+      '</div>' +
+      '<div class="event">' +
+        `<div style="color: ${defaultColors[0]};">` +
+          `<div class="l1">-ful</div>` +
+        `</div>` +
+      '</div>' +
+    '</div>';
+
+    const line = [
+      [
+        { index: 0, offset: 1, voice: 'l1', content: 'Wonder' },
+      ],
+      [
+        { index: 0, offset: 0, voice: 'l1', content: '-ful' },
+      ]
+    ];
+
+    const chordsRenderer = new ChordsEventRenderer(['l1'], voiceColors);
+    const actualLineDiv = chordsRenderer.createLineDiv(line);
+
+    expect(actualLineDiv.outerHTML).toEqual(expectedLineDiv);
+  });
+
+  test('should add space before a voice if it does not start at the start index of an event', () => {
+    const expectedLineDiv ='<div class="line">' +
+      '<div class="event">' +
+        `<div style="color: ${defaultColors[0]};">` +
+          `<div class="c1">   C</div>` +
+        `</div>` +
+        `<div style="color: ${defaultColors[1]};">` +
+          `<div class="l1"> Testing!</div>` +
+        `</div>` +
+      '</div>' +
+    '</div>';
+
+    const line = [
+      [
+        { index: 0, offset: 3, voice: 'c1', content: 'C' },
+        { index: 0, offset: 1, voice: 'l1', content: 'Testing!' },
+      ]
+    ];
+
+    const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors);
+    const actualLineDiv = chordsRenderer.createLineDiv(line);
+
+    expect(actualLineDiv.outerHTML).toEqual(expectedLineDiv);
+    expect(mockAddChordToDivFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/renderers/renderer.css
+++ b/renderers/renderer.css
@@ -17,6 +17,11 @@
   cursor: help;
 }
 
+.highlight {
+  color: red;
+  font-weight: bold;
+}
+
 .diagram {
   border: 1px solid #e3e3e3;
   background: white;

--- a/renderers/renderer.css
+++ b/renderers/renderer.css
@@ -3,6 +3,12 @@
   white-space: pre;
 }
 
+.line {
+  display: flex;
+  flex-wrap: wrap;
+  white-space: pre;
+}
+
 .chart {
   font-family: monospace;
 }

--- a/renderers/voice_colors.js
+++ b/renderers/voice_colors.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const randomColor = require('randomcolor');
+
+class VoiceColors {
+  constructor(defaultColors) {
+    this.colors = defaultColors || ['blue', 'black', 'red', 'green', 'purple', 'teal'];
+    this.voiceColorMap = {};
+  }
+
+  getUnusedColor() {
+    return this.colors.length > 0 ? this.colors.shift() : randomColor({ seed: 42 });
+  }
+
+  getVoiceColor(voice) {
+    if (!(voice in this.voiceColorMap)) {
+      this.voiceColorMap[voice] = this.getUnusedColor();
+    }
+
+    return this.voiceColorMap[voice];
+  }
+}
+
+module.exports = VoiceColors;

--- a/renderers/voice_colors.spec.js
+++ b/renderers/voice_colors.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const VoiceColors = require('./voice_colors.js');
+
+describe('Voice Colors', () => {
+  test('should use the same color for the same voice', () => {
+    const voiceColors = new VoiceColors(['black', 'blue']);
+
+    expect(voiceColors.getVoiceColor('c1')).toEqual('black');
+    expect(voiceColors.getVoiceColor('c1')).toEqual('black');
+    expect(voiceColors.getVoiceColor('l1')).toEqual('blue');
+    expect(voiceColors.getVoiceColor('l1')).toEqual('blue');
+  });
+
+  test('should use the provided default colors before generating colors', () => {
+    const voiceColors = new VoiceColors(['black', 'blue']);
+
+    expect(voiceColors.getVoiceColor('c1')).toEqual('black');
+    expect(voiceColors.getVoiceColor('l1')).toEqual('blue');
+    expect(voiceColors.getVoiceColor('a1')).not.toEqual('black');
+    expect(voiceColors.getVoiceColor('a1')).not.toEqual('blue');
+  });
+
+  test('should be consistent in color generated order so when you come back, it is the same color', () => {
+    const firstVoiceColors = new VoiceColors([]);
+    const secondVoiceColors = new VoiceColors([]);
+
+    expect(firstVoiceColors.getVoiceColor('c1')).toEqual(secondVoiceColors.getVoiceColor('c1'));
+    expect(firstVoiceColors.getVoiceColor('l1')).toEqual(secondVoiceColors.getVoiceColor('l1'));
+  });
+});


### PR DESCRIPTION
Add structure to support #3. Wraps on resize by events instead of voice.

- Add offset (number of characters from previous event to put content) to voices in events. Offset is 1 + difference between start of event and voice index. Split content sets offset to 0 for no space.
- Rename `EventList` to `Line` (let me know if `EventList` is more clear, just felt like `event` was showing up all over the place).
  - Verse -> Phrase -> Line -> Event -> Voice
- Move `VoiceColors` to new file.
- Move adding diagram to chord div to new file.
- Create new renderer to handle events.
- Update default renderer to event based one.
- Emphasize chords that are not in the library.

## Resize and wrap
![render_events](https://user-images.githubusercontent.com/5377267/53998674-6bb99380-40f5-11e9-97b0-337ae2736bfd.gif)

## Emphasize chords missing from library
![image](https://user-images.githubusercontent.com/5377267/53999330-e08dcd00-40f7-11e9-94aa-0e07e7413fcf.png)

