### PR TITLE
Make ABC.js music responsive to resize

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ function MarkdownMusic(md) {
   md.setTranspose = function(transpose) {
     md.userOpts.transpose = transpose;
   };
+
+  // Restricts max renderable width (if the renderer supports it)
+  md.setMaxWidth = function(maxWidth) {
+    md.userOpts.maxWidth = maxWidth;
+  };
 };
 
 module.exports = MarkdownMusic;

--- a/renderers/abc_renderer.js
+++ b/renderers/abc_renderer.js
@@ -4,7 +4,13 @@ const abc = require('abcjs');
 function renderAbc(str, opts) {
   const div = document.createElement('div');
   abc.renderAbc(div, str, {
-    visualTranspose: opts.transpose
+    visualTranspose: opts.transpose,
+    staffwidth: opts.maxWidth,
+    paddingtop: 0,
+    paddingbottom: 0,
+    paddingright: 0,
+    paddingleft: 0,
+    wrap: { minSpacing: 1.8, maxSpacing: 2.7 },
   });
   return div.outerHTML;
 }


### PR DESCRIPTION
This PR adds a new option - maxWidth, which is used by ABC renderer to correctly render the width of the ABC music.

Partially fixes #43 