### PR TITLE
Add basic support to add columns.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,11 @@ function MarkdownMusic(md) {
   md.setMaxWidth = function(maxWidth) {
     md.userOpts.maxWidth = maxWidth;
   };
+
+  // Specified the desired number of columns
+  md.setColumnCount = function(columnCount) {
+    md.userOpts.columnCount = columnCount;
+  };
 };
 
 module.exports = MarkdownMusic;

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function MarkdownMusic(md) {
     md.userOpts.maxWidth = maxWidth;
   };
 
-  // Specified the desired number of columns
+  // Specifies the desired number of columns
   md.setColumnCount = function(columnCount) {
     md.userOpts.columnCount = columnCount;
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -473,7 +473,7 @@
       "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.6.4.tgz",
       "integrity": "sha512-2rx9IQWnJxD6rx5xjdV7Y8IsdKGkwvkrgXJGfMjolYCcoOMLCFnhQj4VlTKy/1sOnL19XdsWscfdhepltB+MUg==",
       "requires": {
-        "midi": "git+https://github.com/paulrosen/MIDI.js.git#abcjs"
+        "midi": "git+https://github.com/paulrosen/MIDI.js.git#e593ffef81a0350f99448e3ab8111957145ff6b2"
       }
     },
     "acorn": {

--- a/parsers/events.js
+++ b/parsers/events.js
@@ -9,7 +9,7 @@
  */
 class Line {
   constructor() {
-    this.spacesBetweenEvents = 1;
+    this.spacesBetweenEvents = 0;
     this.addedCharacters = 0;
     this.previousLine = [];
   }
@@ -91,6 +91,8 @@ class Line {
         voicesAdded.push(voiceName);
       }
     });
+
+    this.spacesBetweenEvents = 1;
 
     return { voicesAdded, line };
   }

--- a/parsers/events.spec.js
+++ b/parsers/events.spec.js
@@ -10,10 +10,10 @@ const Line = eventsjs.__get__('Line');
 describe('Event', () => {
   test('should add voices', () => {
     const expectedLine = [
-      { index: 4, offset: 1, voice: 'c1', content: 'G' },
-      { index: 4, offset: 1, voice: 'c2', content: 'C' },
-      { index: 4, offset: 1, voice: 'l1', content: 'longest' },
-      { index: 4, offset: 1, voice: 'a1', content: 'crash!' },
+      { index: 4, offset: 0, voice: 'c1', content: 'G' },
+      { index: 4, offset: 0, voice: 'c2', content: 'C' },
+      { index: 4, offset: 0, voice: 'l1', content: 'longest' },
+      { index: 4, offset: 0, voice: 'a1', content: 'crash!' },
     ];
 
     const nextVoices = new Map([[
@@ -54,8 +54,8 @@ describe('Event', () => {
     ]);
 
     const expectedLine = [
-      { index: 0, offset: 1, voice: 'l1', content: 'The' },
-      { index: 0, offset: 1, voice: 'l2', content: 'Test' }
+      { index: 0, offset: 0, voice: 'l1', content: 'The' },
+      { index: 0, offset: 0, voice: 'l2', content: 'Test' }
     ];
 
     const line = new Line();
@@ -81,8 +81,8 @@ describe('Event', () => {
     ]);
 
     const expectedLine = [
-      { index: 0, offset: 1, voice: 'c1', content: 'G' },
-      { index: 0, offset: 1, voice: 'l1', content: 'The' }
+      { index: 0, offset: 0, voice: 'c1', content: 'G' },
+      { index: 0, offset: 0, voice: 'l1', content: 'The' }
     ];
 
     const line = new Line();
@@ -125,7 +125,7 @@ describe('Event', () => {
 
     const expectedLines = [
       [
-        [{ index: 0, offset: 1, voice: 'l1', content: 'All' }],
+        [{ index: 0, offset: 0, voice: 'l1', content: 'All' }],
         [{ index: 4, offset: 1, voice: 'l1', content: 'the' }],
         [{ index: 8, offset: 1, voice: 'l1', content: 'leaves' }],
         [{ index: 15, offset: 1, voice: 'l1', content: 'are' }],
@@ -135,7 +135,7 @@ describe('Event', () => {
         ]
       ],
       [
-        [{ index: 0, offset: 1, voice: 'c1', content: new Chord('G') }],
+        [{ index: 0, offset: 0, voice: 'c1', content: new Chord('G') }],
         [{ index: 3, offset: 1, voice: 'c1', content: new Chord('F') }],
         [{ index: 6, offset: 1, voice: 'l1', content: 'and' }],
         [{ index: 10, offset: 1, voice: 'l1', content: 'the' }],
@@ -176,8 +176,8 @@ describe('Event', () => {
     const expectedLines = [
       [
         [
-          { index: 0, offset: 1, voice: 'c1', content: new Chord('A') },
-          { index: 0, offset: 1, voice: 'l1', content: 'longest' },
+          { index: 0, offset: 0, voice: 'c1', content: new Chord('A') },
+          { index: 0, offset: 0, voice: 'l1', content: 'longest' },
         ],
         [
           { index: 8, offset: 1, voice: 'l1', content: 'is' },
@@ -227,8 +227,8 @@ describe('Event', () => {
     const expectedLines = [
       [
         [
-          { index: 0, offset: 1, voice: 'c1', content: new Chord('Am') },
-          { index: 0, offset: 1, voice: 'l1', content: 'Wonder' }
+          { index: 0, offset: 0, voice: 'c1', content: new Chord('Am') },
+          { index: 0, offset: 0, voice: 'l1', content: 'Wonder' }
         ],
         [
           { index: 6, offset: 1, voice: 'c1', content: new Chord('C') },
@@ -237,8 +237,8 @@ describe('Event', () => {
       ],
       [
         [
-          { index: 0, offset: 1, voice: 'c1', content: new Chord('Am') },
-          { index: 0, offset: 1, voice: 'l1', content: 'Test' }
+          { index: 0, offset: 0, voice: 'c1', content: new Chord('Am') },
+          { index: 0, offset: 0, voice: 'l1', content: 'Test' }
         ],
         [
           { index: 4, offset: 1, voice: 'c1', content: new Chord('C') },
@@ -266,8 +266,8 @@ describe('Event', () => {
     const actualLine = line.createLineFromPhrase(phrase, ['c1', 'l1']);
 
     const expectedLine = [
-      { index: 2, voice: 'c1', content: new Chord('C'), offset: 3 },
-      { index: 0, voice: 'l1', content: 'Testing', offset: 1 }
+      { index: 2, voice: 'c1', content: new Chord('C'), offset: 2 },
+      { index: 0, voice: 'l1', content: 'Testing', offset: 0 }
     ];
 
     expect(actualLine).toEqual(expectedLine);

--- a/parsers/events.spec.js
+++ b/parsers/events.spec.js
@@ -126,29 +126,29 @@ describe('Event', () => {
     const expectedLines = [
       [
         [{ index: 0, offset: 0, voice: 'l1', content: 'All' }],
-        [{ index: 4, offset: 0, voice: 'l1', content: 'the' }],
-        [{ index: 8, offset: 0, voice: 'l1', content: 'leaves' }],
-        [{ index: 15, offset: 0, voice: 'l1', content: 'are' }],
+        [{ index: 4, offset: 1, voice: 'l1', content: 'the' }],
+        [{ index: 8, offset: 1, voice: 'l1', content: 'leaves' }],
+        [{ index: 15, offset: 1, voice: 'l1', content: 'are' }],
         [
-          { index: 19, offset: 0, voice: 'c1', content: new Chord('A', 'm') },
-          { index: 19, offset: 0, voice: 'l1', content: 'brown' },
+          { index: 19, offset: 1, voice: 'c1', content: new Chord('A', 'm') },
+          { index: 19, offset: 1, voice: 'l1', content: 'brown' },
         ]
       ],
       [
         [{ index: 0, offset: 0, voice: 'c1', content: new Chord('G') }],
-        [{ index: 3, offset: 0, voice: 'c1', content: new Chord('F') }],
-        [{ index: 6, offset: 0, voice: 'l1', content: 'and' }],
-        [{ index: 10, offset: 0, voice: 'l1', content: 'the' }],
+        [{ index: 3, offset: 1, voice: 'c1', content: new Chord('F') }],
+        [{ index: 6, offset: 1, voice: 'l1', content: 'and' }],
+        [{ index: 10, offset: 1, voice: 'l1', content: 'the' }],
         [
-          { index: 14, offset: 0, voice: 'c1', content: new Chord('G') },
-          { index: 14, offset: 0, voice: 'l1', content: 'sky' },
+          { index: 14, offset: 1, voice: 'c1', content: new Chord('G') },
+          { index: 14, offset: 1, voice: 'l1', content: 'sky' },
         ],
-        [{ index: 18, offset: 0, voice: 'l1', content: 'is' }],
+        [{ index: 18, offset: 1, voice: 'l1', content: 'is' }],
         [
-          { index: 21, offset: 0, voice: 'c1', content: new Chord('E', 'sus2') },
-          { index: 21, offset: 0, voice: 'l1', content: 'gray.' },
+          { index: 21, offset: 1, voice: 'c1', content: new Chord('E', 'sus2') },
+          { index: 21, offset: 1, voice: 'l1', content: 'gray.' },
         ],
-        [{ index: 27, offset: 0, voice: 'c1', content: new Chord('E') }]
+        [{ index: 27, offset: 1, voice: 'c1', content: new Chord('E') }]
       ]
     ];
 
@@ -180,18 +180,18 @@ describe('Event', () => {
           { index: 0, offset: 0, voice: 'l1', content: 'longest' },
         ],
         [
-          { index: 8, offset: 0, voice: 'l1', content: 'is' },
+          { index: 8, offset: 1, voice: 'l1', content: 'is' },
         ],
         [
-          { index: 11, offset: 0, voice: 'c1', content: new Chord('C') },
-          { index: 11, offset: 0, voice: 'l1', content: 'supercali' }
+          { index: 11, offset: 1, voice: 'c1', content: new Chord('C') },
+          { index: 11, offset: 1, voice: 'l1', content: 'supercali' }
         ],
         [
-          { index: 20, offset: 0, voice: 'c1', content: new Chord('D') },
+          { index: 20, offset: 1, voice: 'c1', content: new Chord('D') },
           { index: 20, offset: 0, voice: 'l1', content: '-fragilistic' }
         ],
         [
-          { index: 32, offset: 0, voice: 'c1', content: new Chord('E') },
+          { index: 32, offset: 1, voice: 'c1', content: new Chord('E') },
           { index: 32, offset: 0, voice: 'l1', content: '-expialidocious' }
         ],
       ]
@@ -231,7 +231,7 @@ describe('Event', () => {
           { index: 0, offset: 0, voice: 'l1', content: 'Wonder' }
         ],
         [
-          { index: 6, offset: 0, voice: 'c1', content: new Chord('C') },
+          { index: 6, offset: 1, voice: 'c1', content: new Chord('C') },
           { index: 6, offset: 0, voice: 'l1', content: '-ful' }
         ]
       ],
@@ -241,7 +241,7 @@ describe('Event', () => {
           { index: 0, offset: 0, voice: 'l1', content: 'Test' }
         ],
         [
-          { index: 4, offset: 0, voice: 'c1', content: new Chord('C') },
+          { index: 4, offset: 1, voice: 'c1', content: new Chord('C') },
           { index: 4, offset: 0, voice: 'l1', content: '-ing' }
         ]
       ]

--- a/parsers/events.spec.js
+++ b/parsers/events.spec.js
@@ -126,29 +126,29 @@ describe('Event', () => {
     const expectedLines = [
       [
         [{ index: 0, offset: 0, voice: 'l1', content: 'All' }],
-        [{ index: 4, offset: 1, voice: 'l1', content: 'the' }],
-        [{ index: 8, offset: 1, voice: 'l1', content: 'leaves' }],
-        [{ index: 15, offset: 1, voice: 'l1', content: 'are' }],
+        [{ index: 4, offset: 0, voice: 'l1', content: 'the' }],
+        [{ index: 8, offset: 0, voice: 'l1', content: 'leaves' }],
+        [{ index: 15, offset: 0, voice: 'l1', content: 'are' }],
         [
-          { index: 19, offset: 1, voice: 'c1', content: new Chord('A', 'm') },
-          { index: 19, offset: 1, voice: 'l1', content: 'brown' },
+          { index: 19, offset: 0, voice: 'c1', content: new Chord('A', 'm') },
+          { index: 19, offset: 0, voice: 'l1', content: 'brown' },
         ]
       ],
       [
         [{ index: 0, offset: 0, voice: 'c1', content: new Chord('G') }],
-        [{ index: 3, offset: 1, voice: 'c1', content: new Chord('F') }],
-        [{ index: 6, offset: 1, voice: 'l1', content: 'and' }],
-        [{ index: 10, offset: 1, voice: 'l1', content: 'the' }],
+        [{ index: 3, offset: 0, voice: 'c1', content: new Chord('F') }],
+        [{ index: 6, offset: 0, voice: 'l1', content: 'and' }],
+        [{ index: 10, offset: 0, voice: 'l1', content: 'the' }],
         [
-          { index: 14, offset: 1, voice: 'c1', content: new Chord('G') },
-          { index: 14, offset: 1, voice: 'l1', content: 'sky' },
+          { index: 14, offset: 0, voice: 'c1', content: new Chord('G') },
+          { index: 14, offset: 0, voice: 'l1', content: 'sky' },
         ],
-        [{ index: 18, offset: 1, voice: 'l1', content: 'is' }],
+        [{ index: 18, offset: 0, voice: 'l1', content: 'is' }],
         [
-          { index: 21, offset: 1, voice: 'c1', content: new Chord('E', 'sus2') },
-          { index: 21, offset: 1, voice: 'l1', content: 'gray.' },
+          { index: 21, offset: 0, voice: 'c1', content: new Chord('E', 'sus2') },
+          { index: 21, offset: 0, voice: 'l1', content: 'gray.' },
         ],
-        [{ index: 27, offset: 1, voice: 'c1', content: new Chord('E') }]
+        [{ index: 27, offset: 0, voice: 'c1', content: new Chord('E') }]
       ]
     ];
 
@@ -180,18 +180,18 @@ describe('Event', () => {
           { index: 0, offset: 0, voice: 'l1', content: 'longest' },
         ],
         [
-          { index: 8, offset: 1, voice: 'l1', content: 'is' },
+          { index: 8, offset: 0, voice: 'l1', content: 'is' },
         ],
         [
-          { index: 11, offset: 1, voice: 'c1', content: new Chord('C') },
-          { index: 11, offset: 1, voice: 'l1', content: 'supercali' }
+          { index: 11, offset: 0, voice: 'c1', content: new Chord('C') },
+          { index: 11, offset: 0, voice: 'l1', content: 'supercali' }
         ],
         [
-          { index: 20, offset: 1, voice: 'c1', content: new Chord('D') },
+          { index: 20, offset: 0, voice: 'c1', content: new Chord('D') },
           { index: 20, offset: 0, voice: 'l1', content: '-fragilistic' }
         ],
         [
-          { index: 32, offset: 1, voice: 'c1', content: new Chord('E') },
+          { index: 32, offset: 0, voice: 'c1', content: new Chord('E') },
           { index: 32, offset: 0, voice: 'l1', content: '-expialidocious' }
         ],
       ]
@@ -231,7 +231,7 @@ describe('Event', () => {
           { index: 0, offset: 0, voice: 'l1', content: 'Wonder' }
         ],
         [
-          { index: 6, offset: 1, voice: 'c1', content: new Chord('C') },
+          { index: 6, offset: 0, voice: 'c1', content: new Chord('C') },
           { index: 6, offset: 0, voice: 'l1', content: '-ful' }
         ]
       ],
@@ -241,7 +241,7 @@ describe('Event', () => {
           { index: 0, offset: 0, voice: 'l1', content: 'Test' }
         ],
         [
-          { index: 4, offset: 1, voice: 'c1', content: new Chord('C') },
+          { index: 4, offset: 0, voice: 'c1', content: new Chord('C') },
           { index: 4, offset: 0, voice: 'l1', content: '-ing' }
         ]
       ]

--- a/renderers/chords_renderer_from_events.js
+++ b/renderers/chords_renderer_from_events.js
@@ -11,12 +11,14 @@ class ChordsEventRenderer {
     this.voiceOrder = voiceOrder;
     this.voiceColors = new VoiceColors(colorOrder);
     this.transposeAmount = opts ? opts.transpose : undefined;
+    this.columnCount = opts ? opts.columnCount : 1;
   }
 
   createEventHTMLChordChart(lines) {
     // create chart div
     const chartDiv = document.createElement('div');
     chartDiv.className = 'chart';
+    chartDiv.style.columnCount = this.columnCount;
 
     // create events div for each line list
     lines.forEach((line) => {

--- a/renderers/chords_renderer_from_events.spec.js
+++ b/renderers/chords_renderer_from_events.spec.js
@@ -22,10 +22,10 @@ describe('Chords Renderer from Events', () => {
   test('should create a voice div', () => {
     const expectedVoiceDiv =
       `<div style="color: ${defaultColors[0]};">` +
-        `<div class="c1"> C</div>` +
+        `<div class="c1">C</div>` +
       `</div>`;
 
-    const voice = { index: 0, offset: 1, voice: 'c1', content: 'C' };
+    const voice = { index: 0, offset: 0, voice: 'c1', content: 'C' };
 
     const chordsRenderer = new ChordsEventRenderer(['c1'], voiceColors);
     const actualVoiceDiv = chordsRenderer.createVoiceDiv(voice);
@@ -38,22 +38,22 @@ describe('Chords Renderer from Events', () => {
     const expectedLineDiv = '<div class="line">' +
       '<div class="event">' +
         `<div style="color: ${defaultColors[0]};">` +
-          `<div class="l1"> Line</div>` +
+          `<div class="l1">Line</div>` +
         `</div>` +
       '</div>' +
       '<div class="event">' +
         `<div style="color: ${defaultColors[0]};">` +
-          `<div class="l1"> Test</div>` +
+          `<div class="l1">Test</div>` +
         `</div>` +
       '</div>' +
     '</div>';
 
     const line = [
       [
-        { index: 0, offset: 1, voice: 'l1', content: 'Line' },
+        { index: 0, offset: 0, voice: 'l1', content: 'Line' },
       ],
       [
-        { index: 0, offset: 1, voice: 'l1', content: 'Test' },
+        { index: 0, offset: 0, voice: 'l1', content: 'Test' },
       ]
     ];
 
@@ -65,16 +65,16 @@ describe('Chords Renderer from Events', () => {
 
   test('should add diagram to chord div', () => {
     const line = [
-      { index: 0, offset: 1, voice: 'c1', content: 'C' },
-      { index: 0, offset: 1, voice: 'l1', content: 'Wonderful!' },
+      { index: 0, offset: 0, voice: 'c1', content: 'C' },
+      { index: 0, offset: 0, voice: 'l1', content: 'Wonderful!' },
     ];
 
     const expectedEventDiv = '<div class="event">' +
       `<div style="color: ${defaultColors[0]};">` +
-        `<div class="c1"> C</div>` +
+        `<div class="c1">C</div>` +
       `</div>` +
       `<div style="color: ${defaultColors[1]};">` +
-        `<div class="l1"> Wonderful!</div>` +
+        `<div class="l1">Wonderful!</div>` +
       `</div>` +
     '</div>';
 
@@ -88,18 +88,18 @@ describe('Chords Renderer from Events', () => {
   test('should create a chart that contains two phrases that each contain two lines of events.', () => {
     const lines = [[
       [
-        { index: 0, offset: 1, voice: 'c1', content: 'C' },
-        { index: 0, offset: 1, voice: 'l1', content: 'Wonderful' },
+        { index: 0, offset: 0, voice: 'c1', content: 'C' },
+        { index: 0, offset: 0, voice: 'l1', content: 'Wonderful' },
       ],
       [
-        { index: 0, offset: 1, voice: 'c1', content: 'G' },
-        { index: 0, offset: 1, voice: 'l1', content: 'Testing!' },
+        { index: 0, offset: 0, voice: 'c1', content: 'G' },
+        { index: 0, offset: 0, voice: 'l1', content: 'Testing!' },
       ]
     ],
     [
       [
-        { index: 0, offset: 1, voice: 'c1', content: 'A' },
-        { index: 0, offset: 1, voice: 'l1', content: 'Things' },
+        { index: 0, offset: 0, voice: 'c1', content: 'A' },
+        { index: 0, offset: 0, voice: 'l1', content: 'Things' },
       ],
       [
         { index: 10, offset: 1, voice: 'l1', content: 'IsGreat!' },
@@ -109,32 +109,32 @@ describe('Chords Renderer from Events', () => {
     const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors);
     const actualChartDiv = chordsRenderer.createEventHTMLChordChart(lines);
 
-    const expectedEventDiv = '<div class="chart">' +
+    const expectedEventDiv = '<div class="chart" style="column-count: 1;">' +
       '<div class="line">' +
         '<div class="event">' +
           `<div style="color: ${defaultColors[0]};">` +
-            `<div class="c1"> C</div>` +
+            `<div class="c1">C</div>` +
           `</div>` +
           `<div style="color: ${defaultColors[1]};">` +
-            `<div class="l1"> Wonderful</div>` +
+            `<div class="l1">Wonderful</div>` +
           `</div>` +
         '</div>' +
         '<div class="event">' +
           `<div style="color: ${defaultColors[0]};">` +
-            `<div class="c1"> G</div>` +
+            `<div class="c1">G</div>` +
           `</div>` +
           `<div style="color: ${defaultColors[1]};">` +
-            `<div class="l1"> Testing!</div>` +
+            `<div class="l1">Testing!</div>` +
           `</div>` +
         '</div>' +
       '</div>' +
       '<div class="line">' +
         '<div class="event">' +
           `<div style="color: ${defaultColors[0]};">` +
-            `<div class="c1"> A</div>` +
+            `<div class="c1">A</div>` +
           `</div>` +
           `<div style="color: ${defaultColors[1]};">` +
-            `<div class="l1"> Things</div>` +
+            `<div class="l1">Things</div>` +
           `</div>` +
         '</div>' +
         '<div class="event">' +
@@ -156,7 +156,7 @@ describe('Chords Renderer from Events', () => {
     const expectedLineDiv ='<div class="line">' +
       '<div class="event">' +
         `<div style="color: ${defaultColors[0]};">` +
-          `<div class="l1"> Wonder</div>` +
+          `<div class="l1">Wonder</div>` +
         `</div>` +
       '</div>' +
       '<div class="event">' +
@@ -168,7 +168,7 @@ describe('Chords Renderer from Events', () => {
 
     const line = [
       [
-        { index: 0, offset: 1, voice: 'l1', content: 'Wonder' },
+        { index: 0, offset: 0, voice: 'l1', content: 'Wonder' },
       ],
       [
         { index: 0, offset: 0, voice: 'l1', content: '-ful' },
@@ -185,18 +185,18 @@ describe('Chords Renderer from Events', () => {
     const expectedLineDiv ='<div class="line">' +
       '<div class="event">' +
         `<div style="color: ${defaultColors[0]};">` +
-          `<div class="c1">   C</div>` +
+          `<div class="c1">  C</div>` +
         `</div>` +
         `<div style="color: ${defaultColors[1]};">` +
-          `<div class="l1"> Testing!</div>` +
+          `<div class="l1">Testing!</div>` +
         `</div>` +
       '</div>' +
     '</div>';
 
     const line = [
       [
-        { index: 0, offset: 3, voice: 'c1', content: 'C' },
-        { index: 0, offset: 1, voice: 'l1', content: 'Testing!' },
+        { index: 0, offset: 2, voice: 'c1', content: 'C' },
+        { index: 0, offset: 0, voice: 'l1', content: 'Testing!' },
       ]
     ];
 
@@ -205,5 +205,30 @@ describe('Chords Renderer from Events', () => {
 
     expect(actualLineDiv.outerHTML).toEqual(expectedLineDiv);
     expect(mockAddChordToDivFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('should add columns', () => {
+    const expectedChartDiv = '<div class="chart" style="column-count: 3;">' +
+      '<div class="line">' +
+        '<div class="event">' +
+          `<div style="color: ${defaultColors[0]};">` +
+            `<div class="l1">Testing!</div>` +
+          `</div>` +
+        '</div>' +
+      '</div>' +
+    '</div>';
+
+    const lines = [
+      [
+        [
+          { index: 0, offset: 0, voice: 'l1', content: 'Testing!' },
+        ]
+      ]
+    ];
+
+    const chordsRenderer = new ChordsEventRenderer(['l1'], voiceColors, { columnCount: 3 });
+    const actualChartDiv = chordsRenderer.createEventHTMLChordChart(lines);
+
+    expect(actualChartDiv.outerHTML).toEqual(expectedChartDiv);
   });
 });

--- a/renderers/renderer.css
+++ b/renderers/renderer.css
@@ -7,10 +7,17 @@
   display: flex;
   flex-wrap: wrap;
   white-space: pre;
+  break-inside: avoid;
 }
 
 .chart {
   font-family: monospace;
+  -webkit-column-gap: 4em;
+     -moz-column-gap: 4em;
+          column-gap: 4em;
+  -webkit-column-rule: 1px solid #ddd;
+     -moz-column-rule: 1px solid #ddd;
+          column-rule: 1px solid #ddd;
 }
 
 .chord {


### PR DESCRIPTION
- Fixes bug: Extra space before first word. I may revert this change in the future since it actually helps make columns look better. When you split for columns, splitting a line with have an odd space before. Will revisit this when improving column support.
- Add support for `column-count` in chart. #3 

![basic_columns](https://user-images.githubusercontent.com/5377267/54089472-6d1dd280-4326-11e9-9ed4-0819c5312868.gif)
