### PR TITLE
Remove infinite loop and properly add voices in an event. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const meta = require('markdown-it-meta');
 const abc = require('./renderers/abc_renderer.js');
-const chords = require('./renderers/chords_renderer_from_events.js');
+const chords = require('./renderers/chords_renderer.js');
 
 function MarkdownMusic(md) {
   md.use(meta);

--- a/renderers/chords_renderer.js
+++ b/renderers/chords_renderer.js
@@ -56,7 +56,7 @@ class ChordsEventRenderer {
     }
 
     event.forEach((voice) => {
-      while (voice.voice !== currentVoiceOrder[currentVoiceIndex] && currentVoiceIndex < currentVoiceOrder.length) {
+      while (currentVoiceIndex < currentVoiceOrder.length && voice.voice !== currentVoiceOrder[currentVoiceIndex]) {
         const emptyDiv = document.createElement('div');
         emptyDiv.innerHTML = ' ';
 

--- a/renderers/chords_renderer.js
+++ b/renderers/chords_renderer.js
@@ -9,6 +9,7 @@ const VoiceColors = require('./voice_colors.js');
 class ChordsEventRenderer {
   constructor(voiceOrder, colorOrder, opts) {
     this.voiceOrder = voiceOrder;
+    this.currentPhraseIndex = 0;
     this.voiceColors = new VoiceColors(colorOrder);
     this.transposeAmount = opts ? opts.transpose : undefined;
     this.columnCount = opts && opts.columnCount ? opts.columnCount : 1;
@@ -26,6 +27,7 @@ class ChordsEventRenderer {
     lines.forEach((line) => {
       // create line div for each event
       chartDiv.appendChild(this.createLineDiv(line));
+      this.currentPhraseIndex++;
     });
 
     return chartDiv;
@@ -35,7 +37,6 @@ class ChordsEventRenderer {
     const lineDiv = document.createElement('div');
     lineDiv.className = 'line';
 
-    // add all voices from event to line div
     line.forEach((event) => {
       lineDiv.appendChild(this.createEventDiv(event));
     });
@@ -47,10 +48,15 @@ class ChordsEventRenderer {
     const eventDiv = document.createElement('div');
     eventDiv.className = 'event';
 
+    const currentVoiceOrder = this.voiceOrder[this.currentPhraseIndex];
     let currentVoiceIndex = 0;
 
+    if (event.length > currentVoiceOrder.length) {
+      console.error('There are more voices than the voice order displays. Some data map be lost.');
+    }
+
     event.forEach((voice) => {
-      while (voice.voice !== this.voiceOrder[currentVoiceIndex]) {
+      while (voice.voice !== currentVoiceOrder[currentVoiceIndex] && currentVoiceIndex < currentVoiceOrder.length) {
         const emptyDiv = document.createElement('div');
         emptyDiv.innerHTML = ' ';
 
@@ -90,8 +96,8 @@ class ChordsEventRenderer {
 
 function render(str, opts) {
   const verse = parseVerse(str);
-  // Get voice order from first phrase
-  const voiceOrder = Array.from(verse[0].keys());
+
+  const voiceOrder = verse.map((phrase) => Array.from(phrase.keys()));
 
   const colorOrder = ['black', 'blue', 'red', 'green', 'purple', 'teal'];
 

--- a/renderers/chords_renderer.js
+++ b/renderers/chords_renderer.js
@@ -49,24 +49,19 @@ class ChordsEventRenderer {
     eventDiv.className = 'event';
 
     const currentVoiceOrder = this.voiceOrder[this.currentPhraseIndex];
-    let currentVoiceIndex = 0;
 
     if (event.length > currentVoiceOrder.length) {
       console.error('There are more voices than the voice order displays. Some data map be lost.');
     }
 
-    event.forEach((voice) => {
-      while (currentVoiceIndex < currentVoiceOrder.length && voice.voice !== currentVoiceOrder[currentVoiceIndex]) {
+    currentVoiceOrder.forEach((voice) => {
+      if (event[0] && voice === event[0].voice) {
+        eventDiv.appendChild(this.createVoiceDiv(event.shift()));
+      } else {
         const emptyDiv = document.createElement('div');
         emptyDiv.innerHTML = ' ';
-
         eventDiv.appendChild(emptyDiv);
-        currentVoiceIndex++;
       }
-
-      currentVoiceIndex++;
-
-      eventDiv.appendChild(this.createVoiceDiv(voice));
     });
 
     return eventDiv;

--- a/renderers/chords_renderer.spec.js
+++ b/renderers/chords_renderer.spec.js
@@ -2,7 +2,7 @@
 
 const rewire = require('rewire');
 
-const chordsRendererFromEventsJs = rewire('./chords_renderer_from_events.js');
+const chordsRendererFromEventsJs = rewire('./chords_renderer.js');
 chordsRendererFromEventsJs.__set__('document', document);
 
 const mockAddChordToDivFn = jest.fn(() => 'svg_here');
@@ -27,7 +27,7 @@ describe('Chords Renderer from Events', () => {
 
     const voice = { index: 0, offset: 0, voice: 'c1', content: 'C' };
 
-    const chordsRenderer = new ChordsEventRenderer(['c1'], voiceColors);
+    const chordsRenderer = new ChordsEventRenderer([['c1']], voiceColors);
     const actualVoiceDiv = chordsRenderer.createVoiceDiv(voice);
 
     expect(actualVoiceDiv.outerHTML).toEqual(expectedVoiceDiv);
@@ -57,7 +57,7 @@ describe('Chords Renderer from Events', () => {
       ]
     ];
 
-    const chordsRenderer = new ChordsEventRenderer(['l1'], voiceColors);
+    const chordsRenderer = new ChordsEventRenderer([['l1']], voiceColors);
     const actualLineDiv = chordsRenderer.createLineDiv(line);
 
     expect(actualLineDiv.outerHTML).toEqual(expectedLineDiv);
@@ -78,7 +78,7 @@ describe('Chords Renderer from Events', () => {
       `</div>` +
     '</div>';
 
-    const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors);
+    const chordsRenderer = new ChordsEventRenderer([['c1', 'l1']], voiceColors);
     const actualEventDiv = chordsRenderer.createEventDiv(line);
 
     expect(actualEventDiv.outerHTML).toEqual(expectedEventDiv);
@@ -106,7 +106,7 @@ describe('Chords Renderer from Events', () => {
       ]
     ]];
 
-    const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors);
+    const chordsRenderer = new ChordsEventRenderer([['c1', 'l1'], ['c1', 'l1']], voiceColors);
     const actualChartDiv = chordsRenderer.createEventHTMLChordChart(lines);
 
     const expectedEventDiv = '<div class="chart" style="column-count: 1; font-size: 13px;">' +
@@ -175,7 +175,7 @@ describe('Chords Renderer from Events', () => {
       ]
     ];
 
-    const chordsRenderer = new ChordsEventRenderer(['l1'], voiceColors);
+    const chordsRenderer = new ChordsEventRenderer([['l1']], voiceColors);
     const actualLineDiv = chordsRenderer.createLineDiv(line);
 
     expect(actualLineDiv.outerHTML).toEqual(expectedLineDiv);
@@ -200,7 +200,7 @@ describe('Chords Renderer from Events', () => {
       ]
     ];
 
-    const chordsRenderer = new ChordsEventRenderer(['c1', 'l1'], voiceColors);
+    const chordsRenderer = new ChordsEventRenderer([['c1', 'l1']], voiceColors);
     const actualLineDiv = chordsRenderer.createLineDiv(line);
 
     expect(actualLineDiv.outerHTML).toEqual(expectedLineDiv);
@@ -226,7 +226,7 @@ describe('Chords Renderer from Events', () => {
       ]
     ];
 
-    const chordsRenderer = new ChordsEventRenderer(['l1'], voiceColors, { columnCount: 3 });
+    const chordsRenderer = new ChordsEventRenderer([['l1']], voiceColors, { columnCount: 3 });
     const actualChartDiv = chordsRenderer.createEventHTMLChordChart(lines);
 
     expect(actualChartDiv.outerHTML).toEqual(expectedChartDiv);
@@ -251,7 +251,48 @@ describe('Chords Renderer from Events', () => {
       ]
     ];
 
-    const chordsRenderer = new ChordsEventRenderer(['l1'], voiceColors, { fontSize: 999 });
+    const chordsRenderer = new ChordsEventRenderer([['l1']], voiceColors, { fontSize: 999 });
+    const actualChartDiv = chordsRenderer.createEventHTMLChordChart(lines);
+
+    expect(actualChartDiv.outerHTML).toEqual(expectedChartDiv);
+  });
+
+  test('should render all phrases that have a different set of voices than the first', () => {
+    const expectedChartDiv = '<div class="chart" style="column-count: 1; font-size: 13px;">' +
+      '<div class="line">' +
+        '<div class="event">' +
+          `<div style="color: ${defaultColors[0]};">` +
+            `<div class="l1">Testing!</div>` +
+          `</div>` +
+        '</div>' +
+      '</div>' +
+      '<div class="line">' +
+        '<div class="event">' +
+          `<div style="color: ${defaultColors[1]};">` +
+            `<div class="c1">C</div>` +
+          `</div>` +
+          `<div style="color: ${defaultColors[0]};">` +
+            `<div class="l1">Testing!</div>` +
+          `</div>` +
+        '</div>' +
+      '</div>' +
+    '</div>';
+
+    const lines = [
+      [
+        [
+          { index: 0, offset: 0, voice: 'l1', content: 'Testing!' },
+        ]
+      ],
+      [
+        [
+          { index: 0, offset: 0, voice: 'c1', content: 'C' },
+          { index: 0, offset: 0, voice: 'l1', content: 'Testing!' },
+        ]
+      ]
+    ];
+
+    const chordsRenderer = new ChordsEventRenderer([['l1'], ['c1', 'l1']], voiceColors);
     const actualChartDiv = chordsRenderer.createEventHTMLChordChart(lines);
 
     expect(actualChartDiv.outerHTML).toEqual(expectedChartDiv);


### PR DESCRIPTION
Also rename `chords_renderer_from_events.js` to `chords_renderer.js`.

Fixes #55 : Issue was caused by only looking at the first phrase for voice order. Instead, for each phrase, look at their voice order specifically.