### PR TITLE
Remove catch in markdown-it-music

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,8 @@ function MarkdownMusic(md) {
     highlight: function(str, lang) {
       if (md.highlightRegistry.hasOwnProperty(lang)) {
         const callback = md.highlightRegistry[lang];
-        try {
-          // If we don't start our HTML with <pre, markdown-it will automatically wrap out output in <pre></pre>.
-          return `<pre style="display: none;"></pre>${callback(str, md.meta)}`;
-        } catch (error) {
-          return `<pre>${str}</pre><div class="error">${error}</div>`;
-        }
+        // If we don't start our HTML with <pre, markdown-it will automatically wrap our output in <pre></pre>.
+        return `<pre style="display: none;"></pre>${callback(str, md.meta)}`;
       }
     }
   });


### PR DESCRIPTION
Remove the catch from markdown-it-music. This enables music-markdown to catch instead and surface the error as a snackbar.