### PR TITLE
Publish to NPM via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: node_js
 node_js:
-  - "node"
+- node
+deploy:
+  provider: npm
+  email: vince.lugli@gmail.com
+  api_key: $NPM_KEY
+  on:
+    tags: true
+    repo: music-markdown/markdown-it-music

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-music",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-music",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Renderer for Music Markdown.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Automatically publish tagged builds to npm. Currently, this requires a manually step if you want to publish. I wanted to get this in a working state first, then will look into automatically incrementing the version.

Steps to publish:

1. `git commit` what ever changes you have.
2. `npm version [ major | minor | patch ]`, usually `npm version patch` 
    - There are other options you can find [here](https://docs.npmjs.com/cli/version.html), but I think we'll usually be using those three.
3. `git push`

Fixes #10 