### PR TITLE
Update highlight to render with ::: fence instead of ```.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
   - node
 git:
   branch: master
-before_script:
-  - git checkout master
 script:
   - npm version patch -m "Bump version %s [skip ci]"
 before_deploy:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const meta = require('markdown-it-meta');
+const markdownitfence = require('markdown-it-fence')
 const abc = require('./renderers/abc_renderer.js');
 const ChordsRenderer = require('./renderers/chords_renderer.js');
 const { parseVerse, isVoiceLine } = require('./parsers/verse');
@@ -41,16 +42,6 @@ function MarkdownMusic(md) {
 
   md.renderer.rules.mmd_verse = (tokens, idx) => md.chordsRenderer.renderVerse(tokens[idx].content);
 
-  md.set({
-    highlight: function(str, lang) {
-      if (md.highlightRegistry.hasOwnProperty(lang)) {
-        const callback = md.highlightRegistry[lang];
-        // If we don't start our HTML with <pre, markdown-it will automatically wrap our output in <pre></pre>.
-        return `<pre style="display: none;"></pre>${callback(str, md.meta)}`;
-      }
-    }
-  });
-
   // Renderer registry
   md.highlightRegistry[abc.lang] = abc.callback;
 
@@ -71,6 +62,15 @@ function MarkdownMusic(md) {
     md.userOpts.fontSize = fontSize;
     return md;
   };
+
+  return markdownitfence(md, 'MarkdownMusic', {
+    marker: ':',
+    render: (tokens, idx, _options, env, self) => {
+      const token = tokens[idx];
+      return md.highlightRegistry[token.info](token.content, md.meta);
+    },
+    validate: (name) => name in md.highlightRegistry
+  });
 };
 
 function isBlankLine(state, line) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const meta = require('markdown-it-meta');
-const markdownitfence = require('markdown-it-fence')
+const markdownitfence = require('markdown-it-fence');
 const abc = require('./renderers/abc_renderer.js');
 const ChordsRenderer = require('./renderers/chords_renderer.js');
 const { parseVerse, isVoiceLine } = require('./parsers/verse');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3267,6 +3267,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-it-fence": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-fence/-/markdown-it-fence-0.1.3.tgz",
+      "integrity": "sha512-mdZbkwJUyZXhyDX4QzD+WnIhxWBq9oIIJU22E6jCT7MHgIp79oEOJfwXIl/HqmfIxnXEdC47sBGn4h6chM4DKw=="
+    },
     "markdown-it-meta": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-meta/-/markdown-it-meta-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "abcjs": "^5.6.4",
     "fast-memoize": "^2.5.1",
+    "markdown-it-fence": "^0.1.3",
     "markdown-it-meta": "0.0.1",
     "randomcolor": "^0.5.4",
     "svg.js": "^2.7.1"


### PR DESCRIPTION
Add `markdown-it-fence` plugin to handle `:::` fence block, and highlight when we recognize.