### PR TITLE
More (minor) perf improvements

### DIFF
--- a/lib/createMemoizeCache.js
+++ b/lib/createMemoizeCache.js
@@ -1,0 +1,24 @@
+function createMemoizeCache() {
+  const store = {};
+  return {
+    has(key) {
+      return (key in store) || localStorage.hasOwnProperty(key);
+    },
+    get(key) {
+      if (store[key]) {
+        return store[key];
+      }
+      if (!(key in localStorage)) {
+        return;
+      }
+      store[key] = localStorage.getItem(key);
+      return localStorage.getItem(key);
+    },
+    set(key, value) {
+      store[key] = value;
+      localStorage.setItem(key, value);
+    }
+  };
+}
+
+module.exports = createMemoizeCache;

--- a/renderers/abc_renderer.js
+++ b/renderers/abc_renderer.js
@@ -1,5 +1,7 @@
 'use strict';
 const abc = require('abcjs');
+const memoize = require('fast-memoize');
+const createMemoizeCache = require('../lib/createMemoizeCache.js');
 const MARGIN_RIGHT = 2;
 
 function renderAbc(str, opts) {
@@ -16,8 +18,14 @@ function renderAbc(str, opts) {
   return div.outerHTML;
 }
 
+const memoizedAbc = memoize(renderAbc, {
+  cache: {
+    create: createMemoizeCache
+  }
+});
+
 
 module.exports = {
   'lang': 'abc',
-  'callback': renderAbc
+  'callback': memoizedAbc
 };

--- a/renderers/chord_diagram.js
+++ b/renderers/chord_diagram.js
@@ -1,7 +1,7 @@
 'use strict';
 const memoize = require('fast-memoize');
-
 const SVG = require('svg.js');
+const createMemoizeCache = require('../lib/createMemoizeCache.js');
 
 /** Represents the dimensions of a chord diagram. */
 class ChordBox {
@@ -186,21 +186,7 @@ function renderChordDiagram(voicing, width, height, frets, tuning) {
 
 const memoized = memoize(renderChordDiagram, {
   cache: {
-    create() {
-      const store = {};
-      return {
-        has(key) {
-          return (key in store) || localStorage.hasOwnProperty(key);
-        },
-        get(key) {
-          return store[key] ? store[key] : ( localStorage.getItem(key) || undefined );
-        },
-        set(key, value) {
-          store[key] = value;
-          localStorage.setItem(key, value);
-        }
-      };
-    }
+    create: createMemoizeCache
   }
 });
 


### PR DESCRIPTION
Memoizing abc renderer and actually using leveled caches; update `store` instead of always going to `localStorage` to get item. ~110ms -> ~22ms

I also tried memoizing the entirety of chords renderer, but it didn't cause a large change on performance. It made the code less readable as well, so I don't think it's worth it. 

Fixes #63 

# Baseline (current)

![perf-baseline](https://user-images.githubusercontent.com/5377267/55773146-31207f00-5a44-11e9-98dc-168fdfef7693.png)

# ABC render cache

![perf-no-cache-levels](https://user-images.githubusercontent.com/5377267/55773176-4ac1c680-5a44-11e9-8c55-880cea66df9e.png)

# ABC render cache + cache level

![perf-all](https://user-images.githubusercontent.com/5377267/55773181-4eede400-5a44-11e9-9cfd-baecbba49bfe.png)
