### PR TITLE
Call chords_renderer with opts param.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function MarkdownMusic(md) {
     return true;
   });
 
-  md.renderer.rules.mmd_verse = (tokens, idx) => md.chordsRenderer.renderVerse(tokens[idx].content);
+  md.renderer.rules.mmd_verse = (tokens, idx) => md.chordsRenderer.renderVerse(tokens[idx].content, md.meta);
 
   // Renderer registry
   md.highlightRegistry[abc.lang] = abc.callback;

--- a/renderers/chords_renderer.js
+++ b/renderers/chords_renderer.js
@@ -11,6 +11,10 @@ class ChordsRenderer {
     this.currentPhraseIndex = 0;
     this.voiceColors = new VoiceColors(colorOrder, voiceOrder);
 
+    this.setOptions(opts);
+  }
+
+  setOptions(opts) {
     this.transposeAmount = opts ? opts.transpose : undefined;
     this.fontSize = opts && opts.fontSize ? opts.fontSize : 13;
   }
@@ -86,7 +90,9 @@ class ChordsRenderer {
       `</div>`;
   }
 
-  renderVerse(verse) {
+  renderVerse(verse, opts) {
+    this.setOptions(opts);
+
     this.voiceOrder = verse.map((phrase) => Array.from(phrase.keys()));
     this.currentPhraseIndex = 0;
 


### PR DESCRIPTION
Chords render was not being called with options, such as transpose. Pass these options along so that we properly render the chords when transposed.