### PR TITLE
Chord Annotation

### DIFF
--- a/lib/chord.js
+++ b/lib/chord.js
@@ -101,7 +101,8 @@ function isChord(str) {
 function parseChord(str) {
   const tokens = str.match(CHORD_PATTERN);
   if (!tokens) {
-    throw new Error(`${str} is not a valid chord`);
+    // Unable to parse the chord, assume it is an annotation in a chord line.
+    return str;
   }
   return new Chord(tokens[1], tokens[2], tokens[3]);
 }

--- a/lib/chord.spec.js
+++ b/lib/chord.spec.js
@@ -102,7 +102,7 @@ describe('Chord', () => {
     expect(actual).toEqual(expected);
   });
 
-  test('throws error when chord is invalid', () => {
-    expect(() => parseChord('Ef')).toThrowError('Ef is not a valid chord');
+  test('output string if not able to parse chord', () => {
+    expect(parseChord('Ef')).toEqual('Ef');
   });
 });


### PR DESCRIPTION
Fixes #76 

Allows arbitrary strings to be parsed as part of the chord lines. Has interesting side-effect of highlighting the annotations in "chord not found" color, actually kinda useful, but we can change if we want.

## Markdown
![image](https://user-images.githubusercontent.com/5377267/56062698-20148e00-5d22-11e9-986d-5dcb6fb72fb2.png)

## Render
![image](https://user-images.githubusercontent.com/5377267/56062688-13903580-5d22-11e9-8237-d707fe968c2c.png)
