### PR TITLE
Fix E7 chord

### DIFF
--- a/lib/chordbook.js
+++ b/lib/chordbook.js
@@ -36,7 +36,7 @@ addGuitarChord(parseChord("Dsus4"), "m1 m2 n4,2 n5,3 n6,3");
 
 addGuitarChord(parseChord("E"), "n2,2 n3,2 n4,1");
 addGuitarChord(parseChord("Em"), "n2,2 n3,2");
-addGuitarChord(parseChord("E7"), "n2,2 n3,2 n4,1");
+addGuitarChord(parseChord("E7"), "n2,2 n4,1");
 addGuitarChord(parseChord("Em7"), "n2,2");
 addGuitarChord(parseChord("Em7"), "n2,2 n3,2 n5,3");
 


### PR DESCRIPTION
It looks like there is a mistake in the chordbook for the chord E7.

The chord is currently the same as the E chord.

I fixed the notes following the first way to play it in as in this article : 
https://www.fender.com/articles/chords/learn-how-to-play-e7-guitar-chord